### PR TITLE
feat: implement comprehensive phone ban support for tournament play

### DIFF
--- a/AI_REVIEW_README.md
+++ b/AI_REVIEW_README.md
@@ -1,6 +1,7 @@
 # AI Review System for VGC Hub
 
-This document explains how to use and configure the AI-powered content review system for blog posts in VGC Hub.
+**Summary:**
+This document describes the AI-powered content moderation system for blog posts in VGC Hub. It is intended for developers and administrators who want to configure, customize, or understand how automated content review works in the application.
 
 ## Overview
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,5 +1,8 @@
 # VGC Hub Scalable Architecture
 
+**Summary:**
+This document describes the scalable, high-traffic-ready architecture of VGC Hub, including frontend, backend, and infrastructure. It is intended for technical readers, developers, and system architects interested in how VGC Hub handles large tournaments and real-time features.
+
 ## Overview
 
 This document outlines the scalable architecture designed to handle high-traffic tournament registrations, specifically optimized for scenarios where 10,000+ people compete for 700 spots in real-time.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,6 +1,7 @@
 # VGC Hub Deployment Guide
 
-This guide covers **free** deployment options for your VGC Hub application so your friends can test and use it.
+**Summary:**
+This guide explains how to deploy VGC Hub for free using Vercel, Netlify, or GitHub Pages. It is intended for anyone who wants to share, host, or test the application with friends or the community.
 
 ## 🚀 Quick Deploy Options
 

--- a/PHONE_BAN_FEATURES.md
+++ b/PHONE_BAN_FEATURES.md
@@ -1,0 +1,288 @@
+# Phone Ban Features in VGC Hub
+
+## Overview
+
+VGC Hub has been designed to accommodate the reality that phones are banned during tournament play. This document outlines how the application handles this constraint and provides alternative methods for tournament operations.
+
+## Key Features
+
+### 1. Tournament Policy Management
+
+The `TournamentPolicyService` manages phone ban policies for tournaments:
+
+- **Phone Ban Detection**: Automatically detects when phones are banned for a tournament
+- **Device Restrictions**: Configurable restrictions for different device types
+- **Alternative Methods**: Provides alternative methods for all tournament operations
+
+### 2. Match Slip System
+
+The `MatchSlipService` has been updated to handle phone bans:
+
+#### Digital Match Slips (When Phones Allowed)
+- QR code generation for easy access
+- Touch signatures for quick authentication
+- Real-time result submission
+- Push notifications for updates
+
+#### Paper Match Slips (When Phones Banned)
+- Paper slip number tracking
+- Manual entry by tournament staff
+- Judge verification system
+- Audit trail for all submissions
+
+### 3. Alternative Tournament Operations
+
+#### Match Result Submission
+**When Phones Banned:**
+- Paper match slips with manual entry
+- Table terminals for result submission
+- Judge-assisted submission
+- Manual verification by tournament staff
+
+**When Phones Allowed:**
+- Digital match slips with QR codes
+- Touch signatures
+- Real-time submission
+- Automatic verification
+
+#### Pairing Information
+**When Phones Banned:**
+- Physical pairing boards
+- Table displays
+- Judge announcements
+- Manual check-in systems
+
+**When Phones Allowed:**
+- Push notifications
+- QR code scanning
+- Real-time updates
+- Digital check-in
+
+#### Tournament Updates
+**When Phones Banned:**
+- Announcement boards
+- Judge announcements
+- Table displays
+- Email notifications (between rounds)
+
+**When Phones Allowed:**
+- Push notifications
+- Real-time updates
+- In-app notifications
+- SMS alerts
+
+## Implementation Details
+
+### TournamentPolicyService
+
+```typescript
+// Enable phone ban for a tournament
+await TournamentPolicyService.setPhoneBanPolicy(tournamentId, true, policy);
+
+// Check if phones are banned
+const isBanned = TournamentPolicyService.isPhoneBanned(tournamentId);
+
+// Get alternative methods
+const alternatives = TournamentPolicyService.getAlternativeMethods(tournamentId, 'match_reporting');
+```
+
+### MatchSlipService
+
+```typescript
+// Create match slip (QR codes disabled if phones banned)
+const matchSlip = await MatchSlipService.createMatchSlip(tournamentId, round, table, player1, player2);
+
+// Submit paper match slip
+await MatchSlipService.submitPaperMatchSlip(matchSlipId, playerId, paperSlipNumber);
+
+// Get match slip by table (alternative to QR code)
+const matchSlip = await MatchSlipService.getMatchSlipByTable(tournamentId, round, table);
+```
+
+### TournamentPhoneBanHandler Component
+
+The `TournamentPhoneBanHandler` component automatically detects phone bans and provides appropriate alternatives:
+
+```tsx
+<TournamentPhoneBanHandler
+  tournamentId={tournamentId}
+  operation="match_reporting"
+  onMethodSelected={(method) => {
+    // Handle selected alternative method
+  }}
+/>
+```
+
+## Alternative Methods by Operation
+
+### 1. Match Reporting
+
+| Method | Description | Requires Judge | Available When |
+|--------|-------------|----------------|----------------|
+| Digital Match Slip | Submit through app | No | Phones Allowed |
+| Paper Match Slip | Fill out paper slip | Yes | Phones Banned |
+| Table Terminal | Use provided terminal | No | Phones Banned |
+| Judge Assisted | Have judge enter results | Yes | Always |
+
+### 2. Pairing Check
+
+| Method | Description | Requires Judge | Available When |
+|--------|-------------|----------------|----------------|
+| Push Notifications | Receive on phone | No | Phones Allowed |
+| Pairing Board | Check physical board | No | Phones Banned |
+| Table Display | Check table display | No | Phones Banned |
+| Judge Announcement | Listen for announcements | Yes | Phones Banned |
+
+### 3. Tournament Updates
+
+| Method | Description | Requires Judge | Available When |
+|--------|-------------|----------------|----------------|
+| Push Notifications | Real-time updates | No | Phones Allowed |
+| Announcement Board | Check physical board | No | Phones Banned |
+| Table Display | Check table display | No | Phones Banned |
+| Email Notifications | Check email between rounds | No | Always |
+
+### 4. Team Verification
+
+| Method | Description | Requires Judge | Available When |
+|--------|-------------|----------------|----------------|
+| Digital Verification | Submit through app | No | Phones Allowed |
+| Paper Team Sheet | Submit paper sheet | Yes | Phones Banned |
+| Table Terminal | Use provided terminal | No | Phones Banned |
+| Judge Assisted | Have judge verify | Yes | Always |
+
+### 5. Dispute Resolution
+
+| Method | Description | Requires Judge | Available When |
+|--------|-------------|----------------|----------------|
+| Digital Dispute | Submit through app | No | Phones Allowed |
+| Judge Call | Call judge to table | Yes | Always |
+| Paper Dispute Form | Fill out dispute form | Yes | Always |
+
+## Device Restrictions
+
+The system can configure different restrictions for various device types:
+
+```typescript
+const policy: PhoneBanPolicy = {
+  allowPhones: false,
+  allowTablets: true,
+  allowLaptops: true,
+  allowDesktops: true,
+  phoneRestrictions: [
+    { type: 'app', value: 'VGC Hub', description: 'VGC Hub app not allowed' }
+  ],
+  tabletRestrictions: [],
+  laptopRestrictions: [],
+  desktopRestrictions: []
+};
+```
+
+## Communication Methods
+
+### During Phone Bans
+- **Table Displays**: Each table has a display showing pairings and updates
+- **Announcement Boards**: Physical boards with tournament information
+- **Judge Announcements**: Verbal announcements by tournament staff
+- **Email Notifications**: Sent between rounds when players can check devices
+
+### When Phones Allowed
+- **Push Notifications**: Real-time updates on mobile devices
+- **In-App Notifications**: Updates within the VGC Hub app
+- **SMS Alerts**: For urgent notifications
+- **QR Code Scanning**: Quick access to match information
+
+## Tournament Staff Features
+
+### Admin Panel
+- Enable/disable phone bans for tournaments
+- Configure device restrictions
+- Monitor paper slip submissions
+- Manage judge assignments
+
+### Judge Interface
+- Manual result entry
+- Paper slip verification
+- Dispute resolution
+- Tournament announcements
+
+## Security and Audit
+
+### Audit Trail
+All actions are logged with:
+- Timestamp
+- User ID
+- Action type
+- Device information
+- Method used (digital/paper)
+
+### Verification Process
+1. **Digital Submissions**: Automatic verification with digital signatures
+2. **Paper Submissions**: Manual verification by tournament staff
+3. **Dispute Resolution**: Judge review with full audit trail
+4. **Final Results**: Tournament director approval
+
+## Best Practices
+
+### For Tournament Organizers
+1. **Pre-Tournament Setup**: Configure phone ban policies before registration opens
+2. **Staff Training**: Ensure all staff understand alternative methods
+3. **Equipment Preparation**: Have table terminals and announcement boards ready
+4. **Communication Plan**: Establish clear communication protocols
+
+### For Players
+1. **Pre-Tournament**: Review tournament policies and alternative methods
+2. **During Tournament**: Follow judge instructions for result submission
+3. **Between Rounds**: Check email for updates when devices are allowed
+4. **Disputes**: Use appropriate channels for dispute resolution
+
+### For Judges
+1. **Familiarization**: Understand all alternative methods
+2. **Consistency**: Apply the same standards for all players
+3. **Documentation**: Maintain proper records of all manual entries
+4. **Communication**: Provide clear instructions to players
+
+## Technical Implementation
+
+### Frontend Components
+- `TournamentPhoneBanHandler`: Main component for handling phone bans
+- `MatchResultSubmission`: Handles result submission with alternatives
+- `TournamentPairings`: Updated to show alternative pairing methods
+
+### Backend Services
+- `TournamentPolicyService`: Manages phone ban policies
+- `MatchSlipService`: Handles match slips with phone ban considerations
+- `NotificationService`: Adapts notifications based on phone ban status
+
+### Database Schema
+- Tournament policies table
+- Phone ban configurations
+- Alternative method preferences
+- Audit trail for all actions
+
+## Future Enhancements
+
+### Planned Features
+1. **Offline Mode**: Full offline functionality for tournaments
+2. **Table Terminal App**: Dedicated app for tournament terminals
+3. **Voice Announcements**: Automated voice announcements
+4. **Smart Displays**: AI-powered display management
+5. **Integration APIs**: Connect with tournament management systems
+
+### Scalability Considerations
+1. **Multi-Tournament Support**: Handle multiple concurrent tournaments
+2. **Regional Policies**: Support different policies by region
+3. **Custom Workflows**: Allow tournament-specific workflows
+4. **Analytics**: Track usage patterns and optimize alternatives
+
+## Conclusion
+
+The phone ban features in VGC Hub ensure that tournaments can run smoothly even when mobile devices are restricted. The system provides multiple alternative methods for all tournament operations, maintains security and audit trails, and adapts seamlessly based on tournament policies.
+
+The implementation prioritizes:
+- **User Experience**: Clear instructions and intuitive alternatives
+- **Tournament Integrity**: Proper verification and audit trails
+- **Flexibility**: Configurable policies for different tournaments
+- **Reliability**: Multiple fallback methods for critical operations
+
+This comprehensive approach ensures that VGC Hub remains a valuable tool for tournament management regardless of device restrictions. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # VGC Hub - Pokémon Tournament Tracker
 
-A comprehensive React TypeScript application for tracking Pokémon VGC tournaments, managing teams, and connecting with the competitive community.
+**VGC Hub** is a free, mobile-friendly web application for tracking Pokémon VGC tournaments, managing teams, and connecting with the competitive community. It supports player, professor, and admin views, with real-time pairings, social features, and robust testing. The app is designed for both casual and competitive players, tournament organizers, and admins who want a seamless, all-in-one VGC experience.
+
+## Who is this for?
+- **Players**: Track your tournaments, pairings, and performance.
+- **Professors/Organizers**: Manage events, create tournaments, and oversee registrations.
+- **Admins**: Oversee the platform, moderate content, and manage users.
+- **Community**: Follow players, share teams, and engage with blog content.
+
+## Project Documentation
+- **README.md**: Overview, features, and getting started.
+- **AI_REVIEW_README.md**: Explains the AI-powered content moderation system for blog posts.
+- **ARCHITECTURE.md**: Describes the scalable, high-traffic-ready architecture of VGC Hub.
+- **DEPLOYMENT.md**: Step-by-step guide for deploying VGC Hub for free.
+- **TESTING.md**: Comprehensive testing strategy and instructions for contributors.
 
 ## 🚀 Quick Start
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,6 +1,7 @@
 # VGC Hub Testing Strategy
 
-This document outlines the comprehensive testing strategy for the VGC Hub application, including unit tests, integration tests, performance tests, and end-to-end tests.
+**Summary:**
+This document explains the comprehensive testing strategy for VGC Hub, including unit, integration, performance, and end-to-end tests. It is intended for contributors and maintainers who want to ensure code quality or extend the test suite.
 
 ## Testing Overview
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,20 @@
       "name": "vite-react-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
+        "date-fns": "^4.1.0",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-big-calendar": "^1.19.4",
+        "react-dom": "^18.3.1",
+        "tesseract.js": "^6.0.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
+        "@playwright/test": "^1.42.1",
+        "@testing-library/jest-dom": "^6.4.2",
+        "@testing-library/react": "^14.2.1",
+        "@testing-library/user-event": "^14.5.2",
+        "@types/jest": "^29.5.12",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
@@ -22,12 +30,24 @@
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
         "eslint-plugin-react-refresh": "^0.4.11",
         "globals": "^15.9.0",
+        "jest": "^29.7.0",
+        "jest-environment-jsdom": "^29.7.0",
+        "playwright": "^1.42.1",
         "postcss": "^8.4.35",
         "tailwindcss": "^3.4.1",
+        "ts-jest": "^29.1.2",
+        "tsx": "^4.7.1",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.3.0",
         "vite": "^5.4.2"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.3.tgz",
+      "integrity": "sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -258,6 +278,245 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
+      "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
+      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
+      "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
@@ -288,6 +547,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -337,6 +605,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -627,6 +902,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.6.tgz",
+      "integrity": "sha512-IjA+DcwoVpjEvyxZddDqBY+uJ2Snc6duLpjmkXm/v4xuS3H+3FkLZlDm9ZsAbF9rsfP3zeA0/ArNDORZgrxR/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -644,6 +936,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.6.tgz",
+      "integrity": "sha512-l8ZCvXP0tbTJ3iaqdNf3pjaOSd5ex/e6/omLIQCVBLmHTlfXW3zAxQ4fnDmPLOB1x9xrcSi/xtCWFwCZRIaEwg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -659,6 +968,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.6.tgz",
+      "integrity": "sha512-+SqBcAWoB1fYKmpWoQP4pGtx+pUUC//RNYhFdbcSA16617cchuryuhOCRpPsjCblKukAckWsV+aQ3UKT/RMPcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -980,6 +1306,518 @@
         "node": ">=12"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/core/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/core/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jest/core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
@@ -1066,6 +1904,44 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.1.tgz",
+      "integrity": "sha512-FS8hQ12acieG2dYSksmLOF7BNxnVf2afRJdCuM1eMSxj6QTSE6G4InGF7oApGgDb65MX7AwMVlIkpru0yZA4Xw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@restart/hooks": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
+      "integrity": "sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1355,6 +2231,176 @@
         "win32"
       ]
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
+      "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "lodash": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.3.1.tgz",
+      "integrity": "sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^9.0.0",
+        "@types/react-dom": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/@testing-library/dom": {
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
+      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.1.3",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/aria-query": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "deep-equal": "^2.0.5"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1407,6 +2453,101 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jsdom": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1414,18 +2555,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.0.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.13.tgz",
+      "integrity": "sha512-Qm9OYVOFHFYg3wJoTSrz80hoec5Lia/dPp84do3X7dZvLikQvM1YpmvTBEdIr/e+U8HTkFjLHLnl78K/qjf+jQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1441,6 +2590,43 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/warning": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
+      "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.36.0",
@@ -1733,6 +2919,14 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
       }
     },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "deprecated": "Use your platform's native atob() and btoa() methods instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1746,6 +2940,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.1.0",
+        "acorn-walk": "^8.0.2"
+      }
+    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -1754,6 +2959,32 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -1771,6 +3002,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-regex": {
@@ -1837,6 +3084,47 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -1875,6 +3163,138 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
+      "integrity": "sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1894,6 +3314,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -1952,10 +3378,100 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2010,6 +3526,16 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -2048,6 +3574,134 @@
         "node": ">= 6"
       }
     },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2067,6 +3721,19 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -2092,6 +3759,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2107,6 +3796,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2120,11 +3816,74 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/date-arithmetic": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-arithmetic/-/date-arithmetic-4.1.0.tgz",
+      "integrity": "sha512-QWxYLR5P/6GStZcdem+V1xoto6DMadYWpMXU82ES3/RfR3Wdwr3D0+be7mgOJ+Ov0G9D5Dmb9T17sNLQYj9XOg==",
+      "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2145,12 +3904,142 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dedent": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
+      "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -2159,12 +4048,68 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -2173,6 +4118,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.182",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.182.tgz",
@@ -2180,12 +4141,118 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -2247,6 +4314,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -2381,6 +4470,20 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -2425,6 +4528,63 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2488,6 +4648,16 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2499,6 +4669,39 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/filelist": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/fill-range": {
@@ -2552,6 +4755,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -2569,6 +4788,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -2582,6 +4818,13 @@
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
       }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2608,6 +4851,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2616,6 +4869,91 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -2678,6 +5016,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/globalize": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/globalize/-/globalize-0.1.1.tgz",
+      "integrity": "sha512-5e01v8eLGfuQSOvx2MsDMOWS0GFtCx1wPzQSmcHw4hkxFzrQDBO3Xwg/m8Hr/7qXMrHeOIE29qWVzyv06u1TZA=="
+    },
     "node_modules/globals": {
       "version": "15.15.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
@@ -2691,12 +5034,45 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -2706,6 +5082,48 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -2720,6 +5138,84 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -2748,6 +5244,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2756,6 +5272,117 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-binary-path": {
@@ -2771,6 +5398,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -2779,6 +5436,23 @@
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2807,6 +5481,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2820,6 +5504,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2830,12 +5527,259 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -2851,6 +5795,1008 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
+      "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.3",
+        "chalk": "^4.0.2",
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-circus/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-config/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-config/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-each/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
+      "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/jsdom": "^20.0.0",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jsdom": "^20.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-validate/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/jiti": {
@@ -2882,6 +6828,52 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.1",
+        "acorn-globals": "^7.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.4.2",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.11.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -2899,6 +6891,13 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2937,6 +6936,26 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/levn": {
@@ -2989,6 +7008,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3027,6 +7065,94 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3051,6 +7177,49 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3072,6 +7241,27 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -3119,6 +7309,55 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -3146,11 +7385,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
+      "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3164,6 +7422,102 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "license": "MIT",
+      "bin": {
+        "opencollective-postinstall": "index.js"
       }
     },
     "node_modules/optionator": {
@@ -3216,6 +7570,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -3236,6 +7600,38 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3244,6 +7640,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -3325,6 +7731,132 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.1.tgz",
+      "integrity": "sha512-peWpSwIBmSLi6aW2auvrUtf2DqY16YYcCMO8rTVx486jKmDTJg7UAhyrraP98GB8BoPURZP8+nxO7TSd4cPr5g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.1.tgz",
+      "integrity": "sha512-Nbjs2zjj0htNhzgiy5wu+3w09YetDx5pkrpI/kZotDlDUaYk0HVA5xrBVPdow4SAUIlhgKcJeJg4GRKW6xHusA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -3487,6 +8019,88 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3496,6 +8110,30 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -3530,6 +8168,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-big-calendar": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/react-big-calendar/-/react-big-calendar-1.19.4.tgz",
+      "integrity": "sha512-FrvbDx2LF6JAWFD96LU1jjloppC5OgIvMYUYIPzAw5Aq+ArYFPxAjLqXc4DyxfsQDN0TJTMuS/BIbcSB7Pg0YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "clsx": "^1.2.1",
+        "date-arithmetic": "^4.1.0",
+        "dayjs": "^1.11.7",
+        "dom-helpers": "^5.2.1",
+        "globalize": "^0.1.1",
+        "invariant": "^2.2.4",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "luxon": "^3.2.1",
+        "memoize-one": "^6.0.0",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.40",
+        "prop-types": "^15.8.1",
+        "react-overlays": "^5.2.1",
+        "uncontrollable": "^7.2.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.14.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -3541,6 +8207,39 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "license": "MIT"
+    },
+    "node_modules/react-overlays": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.2.1.tgz",
+      "integrity": "sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.8",
+        "@popperjs/core": "^2.11.6",
+        "@restart/hooks": "^0.4.7",
+        "@types/warning": "^3.0.0",
+        "dom-helpers": "^5.2.0",
+        "prop-types": "^15.7.2",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
       }
     },
     "node_modules/react-refresh": {
@@ -3576,6 +8275,64 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT"
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -3597,6 +8354,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-cwd/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3605,6 +8385,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/reusify": {
@@ -3682,6 +8482,44 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -3699,6 +8537,40 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/shebang-command": {
@@ -3724,6 +8596,82 @@
         "node": ">=8"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -3737,6 +8685,33 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3745,6 +8720,98 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-length/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/string-width": {
@@ -3851,6 +8918,39 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3913,6 +9013,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
@@ -3951,6 +9058,67 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tesseract.js": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-6.0.1.tgz",
+      "integrity": "sha512-/sPvMvrCtgxnNRCjbTYbr7BRu0yfWDsMZQ2a/T5aN/L1t8wUQN6tTWv6p6FwzpoEBA0jrN2UD2SX4QQFRdoDbA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bmp-js": "^0.1.0",
+        "idb-keyval": "^6.2.0",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.9",
+        "opencollective-postinstall": "^2.0.3",
+        "regenerator-runtime": "^0.13.3",
+        "tesseract.js-core": "^6.0.0",
+        "wasm-feature-detect": "^1.2.11",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/tesseract.js-core": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-6.0.0.tgz",
+      "integrity": "sha512-1Qncm/9oKM7xgrQXZXNB+NRh19qiXGhxlrR8EwFbK5SaUbPZnS5OMtP/ghtqfd23hsr1ZvZbZjeuAGcMxd/ooA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -3974,6 +9142,13 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3985,6 +9160,35 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4007,6 +9211,538 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/ts-jest": {
+      "version": "29.4.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.0.tgz",
+      "integrity": "sha512-d423TJMnJGu80/eSgfQ5w/R+0zFJvdtTxwtF9KzFFunOpSeD+79lHJQIiAhluJoyGRbvj9NZJsl9WjCUo0ND7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "ejs": "^3.1.10",
+        "fast-json-stable-stringify": "^2.1.0",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.2",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.20.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
+      "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.6.tgz",
+      "integrity": "sha512-ShbM/3XxwuxjFiuVBHA+d3j5dyac0aEVVq1oluIDf71hUw0aRF59dV/efUsIwFnR6m8JNM2FjZOzmaZ8yG61kw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.6.tgz",
+      "integrity": "sha512-S8ToEOVfg++AU/bHwdksHNnyLyVM+eMVAOf6yRKFitnwnbwwPNqKr3srzFRe7nzV69RQKb5DgchIX5pt3L53xg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.6.tgz",
+      "integrity": "sha512-hd5zdUarsK6strW+3Wxi5qWws+rJhCCbMiC9QZyzoxfk5uHRIE8T287giQxzVpEvCwuJ9Qjg6bEjcRJcgfLqoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.6.tgz",
+      "integrity": "sha512-0Z7KpHSr3VBIO9A/1wcT3NTy7EB4oNC4upJ5ye3R7taCc2GUdeynSLArnon5G8scPwaU866d3H4BCrE5xLW25A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.6.tgz",
+      "integrity": "sha512-FFCssz3XBavjxcFxKsGy2DYK5VSvJqa6y5HXljKzhRZ87LvEi13brPrf/wdyl/BbpbMKJNOr1Sd0jtW4Ge1pAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.6.tgz",
+      "integrity": "sha512-GfXs5kry/TkGM2vKqK2oyiLFygJRqKVhawu3+DOCk7OxLy/6jYkWXhlHwOoTb0WqGnWGAS7sooxbZowy+pK9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.6.tgz",
+      "integrity": "sha512-aoLF2c3OvDn2XDTRvn8hN6DRzVVpDlj2B/F66clWd/FHLiHaG3aVZjxQX2DYphA5y/evbdGvC6Us13tvyt4pWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.6.tgz",
+      "integrity": "sha512-2SkqTjTSo2dYi/jzFbU9Plt1vk0+nNg8YC8rOXXea+iA3hfNJWebKYPs3xnOUf9+ZWhKAaxnQNUf2X9LOpeiMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.6.tgz",
+      "integrity": "sha512-SZHQlzvqv4Du5PrKE2faN0qlbsaW/3QQfUUc6yO2EjFcA83xnwm91UbEEVx4ApZ9Z5oG8Bxz4qPE+HFwtVcfyw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.6.tgz",
+      "integrity": "sha512-b967hU0gqKd9Drsh/UuAm21Khpoh6mPBSgz8mKRq4P5mVK8bpA+hQzmm/ZwGVULSNBzKdZPQBRT3+WuVavcWsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.6.tgz",
+      "integrity": "sha512-aHWdQ2AAltRkLPOsKdi3xv0mZ8fUGPdlKEjIEhxCPm5yKEThcUjHpWB1idN74lfXGnZ5SULQSgtr5Qos5B0bPw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.6.tgz",
+      "integrity": "sha512-VgKCsHdXRSQ7E1+QXGdRPlQ/e08bN6WMQb27/TMfV+vPjjTImuT9PmLXupRlC90S1JeNNW5lzkAEO/McKeJ2yg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.6.tgz",
+      "integrity": "sha512-WViNlpivRKT9/py3kCmkHnn44GkGXVdXfdc4drNmRl15zVQ2+D2uFwdlGh6IuK5AAnGTo2qPB1Djppj+t78rzw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.6.tgz",
+      "integrity": "sha512-wyYKZ9NTdmAMb5730I38lBqVu6cKl4ZfYXIs31Baf8aoOtB4xSGi3THmDYt4BTFHk7/EcVixkOV2uZfwU3Q2Jw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.6.tgz",
+      "integrity": "sha512-KZh7bAGGcrinEj4qzilJ4hqTY3Dg2U82c8bv+e1xqNqZCrCyc+TL9AUEn5WGKDzm3CfC5RODE/qc96OcbIe33w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.6.tgz",
+      "integrity": "sha512-9N1LsTwAuE9oj6lHMyyAM+ucxGiVnEqUdp4v7IaMmrwb06ZTEVCIs3oPPplVsnjPfyjmxwHxHMF8b6vzUVAUGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.6.tgz",
+      "integrity": "sha512-A6bJB41b4lKFWRKNrWoP2LHsjVzNiaurf7wyj/XtFNTsnPuxwEBWHLty+ZE0dWBKuSK1fvKgrKaNjBS7qbFKig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.6.tgz",
+      "integrity": "sha512-dUXuZr5WenIDlMHdMkvDc1FAu4xdWixTCRgP7RQLBOkkGgwuuzaGSYcOpW4jFxzpzL1ejb8yF620UxAqnBrR9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.6.tgz",
+      "integrity": "sha512-hKrmDa0aOFOr71KQ/19JC7az1P0GWtCN1t2ahYAf4O007DHZt/dW8ym5+CUdJhQ/qkZmI1HAF8KkJbEFtCL7gw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.6.tgz",
+      "integrity": "sha512-dyCGxv1/Br7MiSC42qinGL8KkG4kX0pEsdb0+TKhmJZgCUDBGmyo1/ArCjNGiOLiIAgdbWgmWgib4HoCi5t7kA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.6.tgz",
+      "integrity": "sha512-42QOgcZeZOvXfsCBJF5Afw73t4veOId//XD3i+/9gSkhSV6Gk3VPlWncctI+JcOyERv85FUo7RxuxGy+z8A43Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.6.tgz",
+      "integrity": "sha512-4AWhgXmDuYN7rJI6ORB+uU9DHLq/erBbuMoAuB4VWJTu5KtCgcKYPynF0YI1VkBNuEfjNlLrFr9KZPJzrtLkrQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.6.tgz",
+      "integrity": "sha512-NgJPHHbEpLQgDH2MjQu90pzW/5vvXIZ7KOnPyNBm92A6WgZ/7b6fJyUBjoumLqeOQQGqY2QjQxRo97ah4Sj0cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.6.tgz",
+      "integrity": "sha512-GVuzuUwtdsghE3ocJ9Bs8PNoF13HNQ5TXbEi2AhvVb8xU1Iwt9Fos9FEamfoee+u/TOsn7GUWc04lz46n2bbTg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.6",
+        "@esbuild/android-arm": "0.25.6",
+        "@esbuild/android-arm64": "0.25.6",
+        "@esbuild/android-x64": "0.25.6",
+        "@esbuild/darwin-arm64": "0.25.6",
+        "@esbuild/darwin-x64": "0.25.6",
+        "@esbuild/freebsd-arm64": "0.25.6",
+        "@esbuild/freebsd-x64": "0.25.6",
+        "@esbuild/linux-arm": "0.25.6",
+        "@esbuild/linux-arm64": "0.25.6",
+        "@esbuild/linux-ia32": "0.25.6",
+        "@esbuild/linux-loong64": "0.25.6",
+        "@esbuild/linux-mips64el": "0.25.6",
+        "@esbuild/linux-ppc64": "0.25.6",
+        "@esbuild/linux-riscv64": "0.25.6",
+        "@esbuild/linux-s390x": "0.25.6",
+        "@esbuild/linux-x64": "0.25.6",
+        "@esbuild/netbsd-arm64": "0.25.6",
+        "@esbuild/netbsd-x64": "0.25.6",
+        "@esbuild/openbsd-arm64": "0.25.6",
+        "@esbuild/openbsd-x64": "0.25.6",
+        "@esbuild/openharmony-arm64": "0.25.6",
+        "@esbuild/sunos-x64": "0.25.6",
+        "@esbuild/win32-arm64": "0.25.6",
+        "@esbuild/win32-ia32": "0.25.6",
+        "@esbuild/win32-x64": "0.25.6"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4018,6 +9754,29 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -4055,6 +9814,38 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/uncontrollable": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
+      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.6.3",
+        "@types/react": ">=16.9.11",
+        "invariant": "^2.2.4",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -4098,12 +9889,38 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.19",
@@ -4165,6 +9982,91 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4179,6 +10081,67 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/word-wrap": {
@@ -4286,6 +10249,83 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -4306,6 +10346,80 @@
         "node": ">= 14.6"
       }
     },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -4317,6 +10431,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,12 +25,20 @@
     "test:debug": "jest --verbose --detectOpenHandles --forceExit"
   },
   "dependencies": {
+    "date-fns": "^4.1.0",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-big-calendar": "^1.19.4",
+    "react-dom": "^18.3.1",
+    "tesseract.js": "^6.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
+    "@playwright/test": "^1.42.1",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/jest": "^29.5.12",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
@@ -39,26 +47,23 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.11",
     "globals": "^15.9.0",
-    "postcss": "^8.4.35",
-    "tailwindcss": "^3.4.1",
-    "typescript": "^5.5.3",
-    "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2",
-    "@testing-library/react": "^14.2.1",
-    "@testing-library/jest-dom": "^6.4.2",
-    "@testing-library/user-event": "^14.5.2",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "@types/jest": "^29.5.12",
-    "ts-jest": "^29.1.2",
     "playwright": "^1.42.1",
-    "@playwright/test": "^1.42.1",
-    "tsx": "^4.7.1"
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.1",
+    "ts-jest": "^29.1.2",
+    "tsx": "^4.7.1",
+    "typescript": "^5.5.3",
+    "typescript-eslint": "^8.3.0",
+    "vite": "^5.4.2"
   },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "jsdom",
-    "setupFilesAfterEnv": ["<rootDir>/src/tests/setup.ts"],
+    "setupFilesAfterEnv": [
+      "<rootDir>/src/tests/setup.ts"
+    ],
     "moduleNameMapping": {
       "\\.(css|less|scss|sass)$": "identity-obj-proxy",
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/src/tests/__mocks__/fileMock.js"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ function App() {
   const [needsDateOfBirth, setNeedsDateOfBirth] = useState(false);
   const [tempUserInfo, setTempUserInfo] = useState<{ email: string; password: string } | null>(null);
   const [showLogoutNotification, setShowLogoutNotification] = useState(false);
+  const [currentView, setCurrentView] = useState<'competitor' | 'professor' | 'admin'>('competitor');
 
   const handleLogin = (userInfo: {
     email: string;
@@ -28,13 +29,17 @@ function App() {
   };
 
   const handleDateOfBirthComplete = (division: 'junior' | 'senior' | 'master', dateOfBirth: string) => {
+    // Check if this is Manraj Sidhu's login
+    const isManrajSidhu = tempUserInfo?.email === 'manraj.sidhu@gmail.com';
+    
     // Create user session with the determined division
     const session: UserSession = {
-      userId: 'user-123',
+      userId: isManrajSidhu ? 'manraj-sidhu' : 'user-123',
       division: division,
       isGuardian: false,
       permissions: division === 'master' ? ['full-access'] : ['restricted-access'],
       dateOfBirth: dateOfBirth,
+      name: isManrajSidhu ? 'Manraj Sidhu' : undefined,
     };
     setUserSession(session);
     setNeedsDateOfBirth(false);
@@ -99,25 +104,30 @@ function App() {
 
   const handleGoHome = () => {
     // Reset any deep navigation states and return to main dashboard
-    setShowHome(false); // Ensure we're not on the landing page
+    setShowHome(true); // Show the homepage
     // The main dashboard will be shown by the existing logic
+  };
+
+  const handleSwitchView = (view: 'competitor' | 'professor' | 'admin') => {
+    setCurrentView(view);
   };
 
   const renderMainContent = () => {
     if (!userSession) return null;
 
-    // Determine user type and render appropriate view
-    if (isAdmin || isProfessor || isPokemonCompanyOfficial) {
+    // Determine which view to render based on currentView state
+    if (currentView === 'admin' || currentView === 'professor') {
       return (
         <AdminProfessorView
           userSession={userSession}
           onLogout={handleLogout}
           onGoHome={handleGoHome}
-          isAdmin={isAdmin}
-          isProfessor={isProfessor}
-          isPokemonCompanyOfficial={isPokemonCompanyOfficial}
-          professorLevel={professorLevel}
-          certificationNumber={certificationNumber}
+          isAdmin={currentView === 'admin'}
+          isProfessor={currentView === 'professor'}
+          isPokemonCompanyOfficial={currentView === 'admin'}
+          professorLevel={currentView === 'professor' ? 'full' : undefined}
+          certificationNumber={currentView === 'professor' ? 'PROF-2023-001' : undefined}
+          onSwitchView={handleSwitchView}
         />
       );
     } else {
@@ -126,6 +136,7 @@ function App() {
           userSession={userSession}
           onLogout={handleLogout}
           onGoHome={handleGoHome}
+          onSwitchView={handleSwitchView}
         />
       );
     }

--- a/src/components/AdminProfessorView.tsx
+++ b/src/components/AdminProfessorView.tsx
@@ -19,6 +19,7 @@ interface AdminProfessorViewProps {
   isPokemonCompanyOfficial: boolean;
   professorLevel?: string;
   certificationNumber?: string;
+  onSwitchView?: (view: 'competitor' | 'professor' | 'admin') => void;
 }
 
 const AdminProfessorView: React.FC<AdminProfessorViewProps> = ({ 
@@ -29,11 +30,13 @@ const AdminProfessorView: React.FC<AdminProfessorViewProps> = ({
   isProfessor, 
   isPokemonCompanyOfficial,
   professorLevel,
-  certificationNumber
+  certificationNumber,
+  onSwitchView
 }) => {
   const [activeTab, setActiveTab] = useState<AdminTabType>('dashboard');
   const [selectedTournament, setSelectedTournament] = useState<string | null>(mockTournaments[0]?.id || null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [showSettings, setShowSettings] = useState(false);
 
   const mockTournament = mockTournaments[0];
 
@@ -67,6 +70,17 @@ const AdminProfessorView: React.FC<AdminProfessorViewProps> = ({
   const handleTabChange = useCallback((tabId: AdminTabType) => {
     setActiveTab(tabId);
   }, []);
+
+  const handleSettingsToggle = useCallback(() => {
+    setShowSettings(prev => !prev);
+  }, []);
+
+  const handleViewSwitch = useCallback((view: 'competitor' | 'professor' | 'admin') => {
+    if (onSwitchView) {
+      onSwitchView(view);
+    }
+    setShowSettings(false);
+  }, [onSwitchView]);
 
   const renderActiveTab = () => {
     switch (activeTab) {
@@ -357,6 +371,14 @@ const AdminProfessorView: React.FC<AdminProfessorViewProps> = ({
               <p className="text-xs text-gray-500 capitalize">{userSession.division} Division</p>
             </div>
             <button
+              onClick={handleSettingsToggle}
+              className="p-2 rounded-full hover:bg-gray-100 transition-colors"
+              disabled={isLoading}
+              aria-label="Settings"
+            >
+              <Settings className="h-5 w-5 text-gray-600" />
+            </button>
+            <button
               onClick={onGoHome}
               className="p-2 rounded-full hover:bg-gray-100 transition-colors"
               disabled={isLoading}
@@ -384,6 +406,116 @@ const AdminProfessorView: React.FC<AdminProfessorViewProps> = ({
           <div className="bg-white rounded-lg p-6 flex items-center space-x-3">
             <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-red-600"></div>
             <span className="text-gray-700">Loading...</span>
+          </div>
+        </div>
+      )}
+
+      {/* Settings Modal */}
+      {showSettings && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-2xl max-w-md w-full mx-4 p-6">
+            <div className="flex items-center justify-between mb-6">
+              <h3 className="text-xl font-bold text-gray-900">Settings</h3>
+              <button
+                onClick={handleSettingsToggle}
+                className="p-2 rounded-full hover:bg-gray-100 transition-colors"
+              >
+                <svg className="h-5 w-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+
+            <div className="space-y-4">
+              <div>
+                <h4 className="font-semibold text-gray-900 mb-3">Switch View</h4>
+                <div className="space-y-2">
+                  <button
+                    onClick={() => handleViewSwitch('competitor')}
+                    className="w-full flex items-center justify-between p-4 bg-blue-50 border border-blue-200 rounded-xl hover:bg-blue-100 transition-colors"
+                  >
+                    <div className="flex items-center space-x-3">
+                      <div className="w-10 h-10 bg-blue-600 rounded-lg flex items-center justify-center">
+                        <svg className="h-5 w-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v13m0-13V6a2 2 0 112 2h-2zm0 0V5.5A2.5 2.5 0 109.5 8H12zm-7 4h14M5 12a2 2 0 110-4h14a2 2 0 110 4M5 12v7a2 2 0 002 2h10a2 2 0 002-2v-7" />
+                        </svg>
+                      </div>
+                      <div className="text-left">
+                        <p className="font-medium text-gray-900">Competitor View</p>
+                        <p className="text-sm text-gray-600">Standard player interface</p>
+                      </div>
+                    </div>
+                    <div className="px-3 py-1 bg-blue-600 text-white rounded-full text-sm font-medium">
+                      Available
+                    </div>
+                  </button>
+
+                  <button
+                    onClick={() => handleViewSwitch('professor')}
+                    className="w-full flex items-center justify-between p-4 bg-orange-50 border border-orange-200 rounded-xl hover:bg-orange-100 transition-colors"
+                  >
+                    <div className="flex items-center space-x-3">
+                      <div className="w-10 h-10 bg-orange-600 rounded-lg flex items-center justify-center">
+                        <svg className="h-5 w-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+                        </svg>
+                      </div>
+                      <div className="text-left">
+                        <p className="font-medium text-gray-900">Professor View</p>
+                        <p className="text-sm text-gray-600">Tournament creation & management</p>
+                      </div>
+                    </div>
+                    <div className="px-3 py-1 bg-orange-600 text-white rounded-full text-sm font-medium">
+                      {isProfessor ? 'Current' : 'Available'}
+                    </div>
+                  </button>
+
+                  <button
+                    onClick={() => handleViewSwitch('admin')}
+                    className="w-full flex items-center justify-between p-4 bg-red-50 border border-red-200 rounded-xl hover:bg-red-100 transition-colors"
+                  >
+                    <div className="flex items-center space-x-3">
+                      <div className="w-10 h-10 bg-red-600 rounded-lg flex items-center justify-center">
+                        <svg className="h-5 w-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                        </svg>
+                      </div>
+                      <div className="text-left">
+                        <p className="font-medium text-gray-900">Admin View</p>
+                        <p className="text-sm text-gray-600">Full system administration</p>
+                      </div>
+                    </div>
+                    <div className="px-3 py-1 bg-red-600 text-white rounded-full text-sm font-medium">
+                      {isAdmin ? 'Current' : 'Available'}
+                    </div>
+                  </button>
+                </div>
+              </div>
+
+              <div className="border-t pt-4">
+                <h4 className="font-semibold text-gray-900 mb-3">Account Settings</h4>
+                <div className="space-y-2">
+                  <button className="w-full flex items-center justify-between p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors">
+                    <span className="text-gray-700">Profile Settings</span>
+                    <svg className="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                    </svg>
+                  </button>
+                  <button className="w-full flex items-center justify-between p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors">
+                    <span className="text-gray-700">Privacy Settings</span>
+                    <svg className="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                    </svg>
+                  </button>
+                  <button className="w-full flex items-center justify-between p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors">
+                    <span className="text-gray-700">Notification Preferences</span>
+                    <svg className="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       )}

--- a/src/components/EventCalendar.tsx
+++ b/src/components/EventCalendar.tsx
@@ -1,6 +1,24 @@
-import React, { useState, useEffect } from 'react';
-import { Calendar, MapPin, Users, Filter, Navigation, Globe, Map } from 'lucide-react';
+import React, { useState, useMemo } from 'react';
+import { Calendar as LucideCalendar, MapPin, Users, Filter, Navigation, Globe, Map } from 'lucide-react';
+import { Calendar as BigCalendar, dateFnsLocalizer } from 'react-big-calendar';
+import format from 'date-fns/format';
+import parse from 'date-fns/parse';
+import startOfWeek from 'date-fns/startOfWeek';
+import getDay from 'date-fns/getDay';
+import enUS from 'date-fns/locale/en-US';
+import 'react-big-calendar/lib/css/react-big-calendar.css';
 import ScalableTournamentRegistration from './ScalableTournamentRegistration';
+
+const locales = {
+  'en-US': enUS,
+};
+const localizer = dateFnsLocalizer({
+  format,
+  parse,
+  startOfWeek: () => startOfWeek(new Date(), { weekStartsOn: 1 }),
+  getDay,
+  locales,
+});
 
 interface Event {
   id: string;
@@ -16,17 +34,19 @@ interface Event {
   isRSVPed: boolean;
   description: string;
   distance?: number; // Distance from user location in km
+  ownerId?: string; // Add ownerId to prevent following yourself
 }
+
+const userId = 'user-123'; // Mock user ID
 
 const EventCalendar: React.FC = () => {
   const [activeTab, setActiveTab] = useState<'tournaments' | 'local'>('tournaments');
-  const [selectedMonth, setSelectedMonth] = useState(new Date());
-  const [userLocation, setUserLocation] = useState<{ lat: number; lng: number } | null>(null);
   const [selectedCountry, setSelectedCountry] = useState<string>('all');
-  const [locationPermission, setLocationPermission] = useState<'granted' | 'denied' | 'pending'>('pending');
   const [filterMode, setFilterMode] = useState<'location' | 'country'>('location');
+  const [userLocation, setUserLocation] = useState<{ lat: number; lng: number } | null>(null);
+  const [locationPermission, setLocationPermission] = useState<'granted' | 'denied' | 'pending'>('pending');
   const [registrationModalTournament, setRegistrationModalTournament] = useState<any>(null);
-  const [userId] = useState('user-123'); // Mock user ID
+  const [selectedEvent, setSelectedEvent] = useState<Event | null>(null);
 
   // Mock events data
   const [events] = useState<Event[]>([
@@ -42,7 +62,8 @@ const EventCalendar: React.FC = () => {
       attendees: 256,
       maxAttendees: 300,
       isRSVPed: true,
-      description: 'Official VGC Regional Championships'
+      description: 'Official VGC Regional Championships',
+      ownerId: 'user-123',
     },
     {
       id: '2',
@@ -56,7 +77,8 @@ const EventCalendar: React.FC = () => {
       attendees: 180,
       maxAttendees: 250,
       isRSVPed: false,
-      description: 'European Spring Championships'
+      description: 'European Spring Championships',
+      ownerId: 'user-456',
     },
     {
       id: '3',
@@ -70,7 +92,8 @@ const EventCalendar: React.FC = () => {
       attendees: 320,
       maxAttendees: 400,
       isRSVPed: false,
-      description: 'Asia-Pacific Regional Championships'
+      description: 'Asia-Pacific Regional Championships',
+      ownerId: 'user-789',
     },
     {
       id: '4',
@@ -84,7 +107,8 @@ const EventCalendar: React.FC = () => {
       attendees: 45,
       maxAttendees: 64,
       isRSVPed: false,
-      description: 'Local VGC tournament'
+      description: 'Local VGC tournament',
+      ownerId: 'user-456',
     },
     {
       id: '5',
@@ -98,7 +122,8 @@ const EventCalendar: React.FC = () => {
       attendees: 25,
       maxAttendees: 50,
       isRSVPed: false,
-      description: 'Community meetup and practice session'
+      description: 'Community meetup and practice session',
+      ownerId: 'user-456',
     },
     {
       id: '6',
@@ -112,108 +137,50 @@ const EventCalendar: React.FC = () => {
       attendees: 200,
       maxAttendees: 300,
       isRSVPed: false,
-      description: 'European Regional Championships'
+      description: 'European Regional Championships',
+      ownerId: 'user-456',
     }
   ]);
 
-  // Get user location on component mount
-  useEffect(() => {
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        (position) => {
-          setUserLocation({
-            lat: position.coords.latitude,
-            lng: position.coords.longitude
-          });
-          setLocationPermission('granted');
-        },
-        (error) => {
-          console.log('Location permission denied:', error);
-          setLocationPermission('denied');
-        }
-      );
-    }
-  }, []);
+  // Calendar events for react-big-calendar
+  const calendarEvents = useMemo(() =>
+    events.map(event => {
+      const [hour, minute] = event.time.split(':');
+      const ampm = event.time.toLowerCase().includes('pm');
+      let hourNum = parseInt(hour, 10);
+      if (ampm && hourNum < 12) hourNum += 12;
+      if (!ampm && hourNum === 12) hourNum = 0;
+      const start = new Date(event.date);
+      start.setHours(hourNum, parseInt(minute), 0, 0);
+      const end = new Date(start.getTime() + 2 * 60 * 60 * 1000); // Default 2 hour event
+      return {
+        ...event,
+        start,
+        end,
+        title: event.title,
+        resource: event,
+      };
+    }),
+    [events]
+  );
 
-  // Calculate distance from user location
-  const calculateDistance = (lat1: number, lon1: number, lat2: number, lon2: number): number => {
-    const R = 6371; // Earth's radius in km
-    const dLat = (lat2 - lat1) * Math.PI / 180;
-    const dLon = (lon2 - lon1) * Math.PI / 180;
-    const a = Math.sin(dLat/2) * Math.sin(dLat/2) +
-              Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) *
-              Math.sin(dLon/2) * Math.sin(dLon/2);
-    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
-    return R * c;
-  };
-
-  // Filter events based on active tab and filters
+  // Filter events for sidebar list
   const getFilteredEvents = () => {
     let filtered = events;
-
     if (filterMode === 'country') {
       if (selectedCountry !== 'all') {
         filtered = filtered.filter(event => event.country === selectedCountry);
       }
-    } else if (filterMode === 'location' && userLocation) {
-      filtered = filtered.filter(event => {
-        if (event.coordinates) {
-          const distance = calculateDistance(userLocation.lat, userLocation.lng, event.coordinates.lat, event.coordinates.lng);
-          event.distance = distance;
-          return distance <= 100;
-        }
-        return false;
-      });
-      filtered.sort((a, b) => (a.distance || 0) - (b.distance || 0));
     }
-
-    // Sort by date
+    // No location filter for calendar view for simplicity
     filtered.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
-
     return filtered;
   };
 
-  const handleRSVP = (eventId: string) => {
-    // In a real app, this would make an API call
-    console.log('RSVP for event:', eventId);
-  };
-
-  const getEventTypeColor = (type: string) => {
-    switch (type) {
-      case 'tournament': return 'bg-blue-100 text-blue-800';
-      case 'meetup': return 'bg-green-100 text-green-800';
-      default: return 'bg-gray-100 text-gray-800';
-    }
-  };
-
-  const getEventTypeIcon = (type: string) => {
-    switch (type) {
-      case 'tournament': return '🏆';
-      case 'meetup': return '👥';
-      default: return '📅';
-    }
-  };
-
-  const getCountries = () => {
-    const countries = [...new Set(events.map(event => event.country))];
-    return countries.sort();
-  };
-
-  const formatDistance = (distance: number) => {
-    if (distance < 1) {
-      return `${Math.round(distance * 1000)}m`;
-    }
-    return `${Math.round(distance)}km`;
-  };
-
-  const getRegistrationStatus = (event: Event) => {
-    // Mock logic: if isRSVPed, user is a participant; if spots available, tickets available; else not playing
-    if (event.isRSVPed) return 'participant';
-    if (event.type === 'tournament' && event.maxAttendees && event.attendees < event.maxAttendees) return 'tickets';
-    return 'not_playing';
-  };
-
   const filteredEvents = getFilteredEvents();
+
+  // Prevent following yourself (no RSVP/join for your own events)
+  const canRSVP = (event: Event) => event.ownerId !== userId;
 
   return (
     <div className="px-4 py-6 space-y-6">
@@ -224,241 +191,91 @@ const EventCalendar: React.FC = () => {
             <h2 className="text-2xl font-bold">Event Calendar</h2>
             <p className="text-green-100">Find tournaments and events near you</p>
           </div>
-          <Calendar className="h-8 w-8" />
-        </div>
-        
-        <div className="grid grid-cols-3 gap-4 text-center">
-          <div>
-            <p className="text-2xl font-bold">{events.filter(e => e.type === 'tournament').length}</p>
-            <p className="text-sm text-green-100">Tournaments</p>
-          </div>
-          <div>
-            <p className="text-2xl font-bold">{events.filter(e => e.type === 'meetup').length}</p>
-            <p className="text-sm text-green-100">Meetups</p>
-          </div>
-          <div>
-            <p className="text-2xl font-bold">{filteredEvents.length}</p>
-            <p className="text-sm text-green-100">Available</p>
-          </div>
+          <LucideCalendar className="h-8 w-8" />
         </div>
       </div>
 
-      {/* Tab Navigation */}
-      <div className="flex space-x-2">
-        <button
-          onClick={() => setActiveTab('tournaments')}
-          className={`flex items-center space-x-2 px-4 py-2 rounded-full transition-all ${
-            activeTab === 'tournaments'
-              ? 'bg-green-600 text-white shadow-lg'
-              : 'bg-white text-gray-600 hover:bg-gray-50 border border-gray-200'
-          }`}
-        >
-          <Globe className="h-4 w-4" />
-          <span>Tournaments</span>
-        </button>
-        <button
-          onClick={() => setActiveTab('local')}
-          className={`flex items-center space-x-2 px-4 py-2 rounded-full transition-all ${
-            activeTab === 'local'
-              ? 'bg-green-600 text-white shadow-lg'
-              : 'bg-white text-gray-600 hover:bg-gray-50 border border-gray-200'
-          }`}
-        >
-          <Map className="h-4 w-4" />
-          <span>Local Events</span>
-        </button>
+      {/* Calendar View */}
+      <div className="bg-white rounded-xl p-4 border border-gray-200">
+        <BigCalendar
+          localizer={localizer}
+          events={calendarEvents}
+          startAccessor="start"
+          endAccessor="end"
+          style={{ height: 600 }}
+          popup
+          onSelectEvent={event => setSelectedEvent(event.resource)}
+          eventPropGetter={event => {
+            let backgroundColor = event.type === 'tournament' ? '#2563eb' : '#22c55e';
+            return { style: { backgroundColor, color: 'white', borderRadius: 8, border: 'none', fontWeight: 500 } };
+          }}
+        />
       </div>
 
-      {/* Local Events Filters */}
-      {activeTab === 'local' && (
-        <div className="space-y-4">
-          {/* Location Toggle */}
-          <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-            <div className="flex items-center space-x-2">
-              <Navigation className="h-5 w-5 text-gray-600" />
-              <span className="text-sm font-medium text-gray-700">Location Services</span>
-            </div>
+      {/* Event Details Modal */}
+      {selectedEvent && (
+        <div className="fixed inset-0 bg-black bg-opacity-40 z-50 flex items-center justify-center p-4">
+          <div className="bg-white rounded-2xl max-w-lg w-full p-6 relative">
             <button
-              className={`px-3 py-1 rounded-full text-sm font-medium transition-all ${userLocation ? 'bg-green-600 text-white' : 'bg-gray-300 text-gray-700'}`}
-              onClick={() => {
-                if (userLocation) {
-                  setUserLocation(null);
-                  setLocationPermission('denied');
-                } else {
-                  setLocationPermission('pending');
-                  if (navigator.geolocation) {
-                    navigator.geolocation.getCurrentPosition(
-                      (position) => {
-                        setUserLocation({
-                          lat: position.coords.latitude,
-                          lng: position.coords.longitude
-                        });
-                        setLocationPermission('granted');
-                      },
-                      (error) => {
-                        setLocationPermission('denied');
-                      }
-                    );
-                  }
-                }
-              }}
+              className="absolute top-3 right-3 text-gray-400 hover:text-gray-700"
+              onClick={() => setSelectedEvent(null)}
             >
-              {userLocation ? 'Disable Location' : 'Enable Location'}
+              ×
             </button>
-          </div>
-
-          {/* Location Status */}
-          <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-            <div className="flex items-center space-x-2">
-              <Navigation className="h-5 w-5 text-gray-600" />
-              <span className="text-sm font-medium text-gray-700">Location</span>
+            <div className="flex items-center space-x-2 mb-2">
+              <span className="text-lg">{selectedEvent.type === 'tournament' ? '🏆' : '👥'}</span>
+              <h3 className="font-semibold text-gray-900 text-lg">{selectedEvent.title}</h3>
+              <span className={`px-2 py-1 rounded-full text-xs font-medium ${selectedEvent.type === 'tournament' ? 'bg-blue-100 text-blue-800' : 'bg-green-100 text-green-800'}`}>{selectedEvent.type.charAt(0).toUpperCase() + selectedEvent.type.slice(1)}</span>
             </div>
-            <div className="flex items-center space-x-2">
-              {userLocation && locationPermission === 'granted' ? (
-                <span className="text-sm text-green-600">✓ Location enabled</span>
-              ) : locationPermission === 'denied' ? (
-                <span className="text-sm text-red-600">✗ Location disabled</span>
-              ) : (
-                <span className="text-sm text-yellow-600">⏳ Location not enabled</span>
-              )}
-            </div>
-          </div>
-
-          {/* Filter Mode Selection */}
-          <div className="flex items-center justify-between mb-4">
-            <div className="flex items-center space-x-2">
-              <Filter className="h-5 w-5 text-gray-600" />
-              <span className="font-semibold text-gray-900">Filter Events</span>
-            </div>
-            <div className="flex space-x-2">
-              <button
-                className={`px-3 py-1 rounded-full text-sm transition-all ${filterMode === 'location' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 border border-gray-200'}`}
-                onClick={() => setFilterMode('location')}
-                disabled={!userLocation}
-              >
-                Near Me
-              </button>
-              <button
-                className={`px-3 py-1 rounded-full text-sm transition-all ${filterMode === 'country' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 border border-gray-200'}`}
-                onClick={() => setFilterMode('country')}
-              >
-                By Country
-              </button>
-            </div>
-          </div>
-          {filterMode === 'country' && (
-            <div className="mb-4">
-              <label className="block text-sm font-medium text-gray-700 mb-1">Country</label>
-              <select
-                className="w-full p-2 border border-gray-300 rounded-lg"
-                value={selectedCountry}
-                onChange={e => setSelectedCountry(e.target.value)}
-              >
-                <option value="all">All Countries</option>
-                {[...new Set(events.map(e => e.country))].map(country => (
-                  <option key={country} value={country}>{country}</option>
-                ))}
-              </select>
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Events List */}
-      <div className="space-y-4">
-        {filteredEvents.map((event) => {
-          const regStatus = getRegistrationStatus(event);
-          return (
-            <div key={event.id} className="bg-white rounded-xl p-4 border border-gray-200">
-              <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between mb-3 space-y-3 sm:space-y-0">
-                <div className="flex-1">
-                  <div className="flex items-center space-x-2 mb-2">
-                    <span className="text-lg">{getEventTypeIcon(event.type)}</span>
-                    <h3 className="font-semibold text-gray-900 text-wrap">{event.title}</h3>
-                    <span className={`px-2 py-1 rounded-full text-xs font-medium ${getEventTypeColor(event.type)}`}>{event.type.charAt(0).toUpperCase() + event.type.slice(1)}</span>
-                  </div>
-                  <div className="flex flex-col sm:flex-row sm:items-center space-y-1 sm:space-y-0 sm:space-x-4 text-sm text-gray-600">
-                    <div className="flex items-center space-x-1">
-                      <Calendar className="h-4 w-4" />
-                      <span>{new Date(event.date).toLocaleDateString()}</span>
-                    </div>
-                    <div className="hidden sm:block">•</div>
-                    <span>{event.time}</span>
-                    <div className="hidden sm:block">•</div>
-                    <div className="flex items-center space-x-1">
-                      <MapPin className="h-4 w-4" />
-                      <span className="text-wrap">{event.location}</span>
-                    </div>
-                    {event.distance && (
-                      <>
-                        <div className="hidden sm:block">•</div>
-                        <span className="text-green-600 font-medium">{formatDistance(event.distance)} away</span>
-                      </>
-                    )}
-                  </div>
-                </div>
-                {/* Registration Status Button */}
-                {event.type === 'tournament' && (
-                  <div className="flex-shrink-0">
-                    {regStatus === 'participant' ? (
-                      <span className="px-4 py-2 rounded-full text-sm font-medium bg-green-100 text-green-800 cursor-default min-h-[44px] flex items-center justify-center">Participant</span>
-                    ) : regStatus === 'tickets' ? (
-                      <button
-                        onClick={() => setRegistrationModalTournament(event)}
-                        className="px-4 py-2 rounded-full text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 transition-colors min-h-[44px] flex items-center justify-center"
-                      >
-                        Tickets Available
-                      </button>
-                    ) : (
-                      <span className="px-4 py-2 rounded-full text-sm font-medium bg-gray-100 text-gray-500 cursor-default min-h-[44px] flex items-center justify-center">Not Playing</span>
-                    )}
-                  </div>
-                )}
+            <div className="flex flex-col sm:flex-row sm:items-center space-y-1 sm:space-y-0 sm:space-x-4 text-sm text-gray-600 mb-2">
+              <div className="flex items-center space-x-1">
+                <LucideCalendar className="h-4 w-4" />
+                <span>{new Date(selectedEvent.date).toLocaleDateString()}</span>
               </div>
-              
-              <p className="text-gray-600 text-sm mb-3">{event.description}</p>
-              
-              <div className="flex items-center justify-between text-sm">
-                <div className="flex items-center space-x-4">
-                  <div className="flex items-center space-x-1">
-                    <Users className="h-4 w-4 text-gray-500" />
-                    <span className="text-gray-600">
-                      {event.attendees}{event.maxAttendees ? `/${event.maxAttendees}` : ''} attendees
-                    </span>
-                  </div>
-                  <span className="text-gray-500">•</span>
-                  <span className="text-gray-600">{event.country}</span>
-                </div>
-                {event.maxAttendees && (
-                  <div className={`px-2 py-1 rounded-full text-xs font-medium ${
-                    event.attendees >= event.maxAttendees
-                      ? 'bg-red-100 text-red-800'
-                      : event.attendees >= event.maxAttendees * 0.8
-                      ? 'bg-yellow-100 text-yellow-800'
-                      : 'bg-green-100 text-green-800'
-                  }`}>
-                    {event.attendees >= event.maxAttendees ? 'Full' : 
-                     event.attendees >= event.maxAttendees * 0.8 ? 'Almost Full' : 'Spots Available'}
-                  </div>
-                )}
+              <div className="hidden sm:block">•</div>
+              <span>{selectedEvent.time}</span>
+              <div className="hidden sm:block">•</div>
+              <div className="flex items-center space-x-1">
+                <MapPin className="h-4 w-4" />
+                <span className="text-wrap">{selectedEvent.location}</span>
               </div>
             </div>
-          );
-        })}
-      </div>
-
-      {/* Empty State */}
-      {filteredEvents.length === 0 && (
-        <div className="text-center py-12">
-          <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
-            <Calendar className="h-8 w-8 text-gray-400" />
+            <p className="text-gray-600 text-sm mb-3">{selectedEvent.description}</p>
+            <div className="flex items-center space-x-4 mb-3">
+              <div className="flex items-center space-x-1">
+                <Users className="h-4 w-4 text-gray-500" />
+                <span className="text-gray-600">
+                  {selectedEvent.attendees}{selectedEvent.maxAttendees ? `/${selectedEvent.maxAttendees}` : ''} attendees
+                </span>
+              </div>
+              <span className="text-gray-500">•</span>
+              <span className="text-gray-600">{selectedEvent.country}</span>
+            </div>
+            {selectedEvent.maxAttendees && (
+              <div className={`px-2 py-1 rounded-full text-xs font-medium mb-3 ${
+                selectedEvent.attendees >= selectedEvent.maxAttendees
+                  ? 'bg-red-100 text-red-800'
+                  : selectedEvent.attendees >= selectedEvent.maxAttendees * 0.8
+                  ? 'bg-yellow-100 text-yellow-800'
+                  : 'bg-green-100 text-green-800'
+              }`}>
+                {selectedEvent.attendees >= selectedEvent.maxAttendees ? 'Full' : 
+                 selectedEvent.attendees >= selectedEvent.maxAttendees * 0.8 ? 'Almost Full' : 'Spots Available'}
+              </div>
+            )}
+            {/* RSVP/Join Button (prevent following yourself) */}
+            {selectedEvent.type === 'tournament' && canRSVP(selectedEvent) && (
+              <button
+                onClick={() => setRegistrationModalTournament(selectedEvent)}
+                className="w-full bg-blue-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 mt-2"
+              >
+                {selectedEvent.isRSVPed ? 'Registered' : 'Tickets Available'}
+              </button>
+            )}
+            {selectedEvent.type === 'tournament' && !canRSVP(selectedEvent) && (
+              <span className="w-full block text-center bg-green-100 text-green-800 px-4 py-2 rounded-lg text-sm font-medium mt-2 cursor-default">You are the organizer</span>
+            )}
           </div>
-          <h3 className="text-lg font-semibold text-gray-900 mb-2">No events found</h3>
-          <p className="text-gray-600">
-            {activeTab === 'tournaments' 
-              ? 'No tournaments scheduled for this period.' 
-              : 'No local events found. Try adjusting your filters or location settings.'}
-          </p>
         </div>
       )}
 
@@ -485,6 +302,6 @@ const EventCalendar: React.FC = () => {
       )}
     </div>
   );
-  };
-  
+};
+
 export default EventCalendar;

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -64,7 +64,7 @@ const Login: React.FC<LoginProps> = ({ onLogin, onSwitchToSignUp }) => {
       // Simulate Google OAuth
       await new Promise(resolve => setTimeout(resolve, 1500));
       onLogin({
-        email: 'user@gmail.com',
+        email: 'manraj.sidhu@gmail.com',
         password: 'google-oauth'
       });
     } catch (error) {

--- a/src/components/MatchResultSubmission.tsx
+++ b/src/components/MatchResultSubmission.tsx
@@ -1,0 +1,339 @@
+import React, { useState, useEffect } from 'react';
+import { CheckCircle, XCircle, Clock, AlertTriangle } from 'lucide-react';
+import MatchSlipService from '../services/MatchSlipService';
+import TournamentPolicyService from '../services/TournamentPolicyService';
+import TournamentPhoneBanHandler from './TournamentPhoneBanHandler';
+
+interface MatchResultSubmissionProps {
+  tournamentId: string;
+  matchSlipId: string;
+  player1Id: string;
+  player1Name: string;
+  player2Id: string;
+  player2Name: string;
+  currentPlayerId: string;
+  onResultSubmitted?: (result: any) => void;
+}
+
+const MatchResultSubmission: React.FC<MatchResultSubmissionProps> = ({
+  tournamentId,
+  matchSlipId,
+  player1Id,
+  player1Name,
+  player2Id,
+  player2Name,
+  currentPlayerId,
+  onResultSubmitted,
+}) => {
+  const [matchSlip, setMatchSlip] = useState<any>(null);
+  const [gameResults, setGameResults] = useState<Array<{
+    gameNumber: number;
+    winnerId: string;
+    score: string;
+    duration: number;
+    notes: string;
+  }>>([]);
+  const [currentGame, setCurrentGame] = useState(1);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submissionMethod, setSubmissionMethod] = useState<string>('');
+  const [paperSlipNumber, setPaperSlipNumber] = useState('');
+  const [showPaperForm, setShowPaperForm] = useState(false);
+
+  useEffect(() => {
+    const loadMatchSlip = async () => {
+      const response = await MatchSlipService.getMatchSlip(matchSlipId);
+      if (response.success) {
+        setMatchSlip(response.data);
+        // Initialize game results if not already set
+        if (response.data.games.length === 0) {
+          setGameResults([
+            { gameNumber: 1, winnerId: '', score: '', duration: 0, notes: '' },
+            { gameNumber: 2, winnerId: '', score: '', duration: 0, notes: '' },
+            { gameNumber: 3, winnerId: '', score: '', duration: 0, notes: '' },
+          ]);
+        }
+      }
+    };
+
+    loadMatchSlip();
+  }, [matchSlipId]);
+
+  const isPhoneBanned = TournamentPolicyService.isPhoneBanned(tournamentId);
+  const isCurrentPlayer = currentPlayerId === player1Id || currentPlayerId === player2Id;
+
+  const handleGameResultChange = (gameNumber: number, field: string, value: any) => {
+    setGameResults(prev => prev.map(game => 
+      game.gameNumber === gameNumber 
+        ? { ...game, [field]: value }
+        : game
+    ));
+  };
+
+  const handleMethodSelected = (method: string) => {
+    setSubmissionMethod(method);
+    if (method === 'paper_slip') {
+      setShowPaperForm(true);
+    }
+  };
+
+  const submitDigitalResults = async () => {
+    if (!isCurrentPlayer) {
+      alert('Only players in this match can submit results');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      // Submit each game result
+      for (const gameResult of gameResults) {
+        if (gameResult.winnerId && gameResult.score) {
+          await MatchSlipService.submitGameResult(
+            matchSlipId,
+            gameResult.gameNumber,
+            gameResult.winnerId,
+            gameResult.score,
+            gameResult.duration,
+            currentPlayerId,
+            gameResult.notes
+          );
+        }
+      }
+
+      // Submit signature
+      const deviceInfo = {
+        userAgent: navigator.userAgent,
+        screenResolution: `${screen.width}x${screen.height}`,
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        language: navigator.language,
+      };
+
+      await MatchSlipService.submitSignature(
+        matchSlipId,
+        currentPlayerId,
+        'digital',
+        `DIGITAL_SIGNATURE_${Date.now()}`,
+        deviceInfo
+      );
+
+      onResultSubmitted?.(gameResults);
+    } catch (error) {
+      console.error('Error submitting results:', error);
+      alert('Failed to submit results. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const submitPaperResults = async () => {
+    if (!paperSlipNumber.trim()) {
+      alert('Please enter a paper slip number');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await MatchSlipService.submitPaperMatchSlip(
+        matchSlipId,
+        currentPlayerId,
+        paperSlipNumber
+      );
+
+      onResultSubmitted?.({
+        method: 'paper',
+        paperSlipNumber,
+        gameResults,
+      });
+    } catch (error) {
+      console.error('Error submitting paper results:', error);
+      alert('Failed to submit paper results. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const getWinnerName = (winnerId: string) => {
+    return winnerId === player1Id ? player1Name : player2Name;
+  };
+
+  if (!matchSlip) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <Clock className="h-8 w-8 text-gray-400 animate-spin" />
+        <span className="ml-2 text-gray-600">Loading match slip...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Match Header */}
+      <div className="bg-white border border-gray-200 rounded-lg p-4">
+        <h3 className="text-lg font-semibold text-gray-900 mb-2">Match Result Submission</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="text-center p-3 bg-blue-50 rounded-lg">
+            <div className="font-medium text-blue-900">{player1Name}</div>
+            <div className="text-sm text-blue-600">Player 1</div>
+          </div>
+          <div className="text-center p-3 bg-red-50 rounded-lg">
+            <div className="font-medium text-red-900">{player2Name}</div>
+            <div className="text-sm text-red-600">Player 2</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Phone Ban Handler */}
+      {isPhoneBanned && (
+        <TournamentPhoneBanHandler
+          tournamentId={tournamentId}
+          operation="match_reporting"
+          onMethodSelected={handleMethodSelected}
+        />
+      )}
+
+      {/* Digital Result Submission */}
+      {(!isPhoneBanned || submissionMethod === 'table_terminal') && (
+        <div className="bg-white border border-gray-200 rounded-lg p-4">
+          <h4 className="text-md font-semibold text-gray-900 mb-4">Game Results</h4>
+          
+          {gameResults.map((game, index) => (
+            <div key={game.gameNumber} className="mb-4 p-4 border border-gray-200 rounded-lg">
+              <h5 className="font-medium text-gray-900 mb-3">Game {game.gameNumber}</h5>
+              
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {/* Winner Selection */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    Winner
+                  </label>
+                  <select
+                    value={game.winnerId}
+                    onChange={(e) => handleGameResultChange(game.gameNumber, 'winnerId', e.target.value)}
+                    className="w-full p-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
+                  >
+                    <option value="">Select winner</option>
+                    <option value={player1Id}>{player1Name}</option>
+                    <option value={player2Id}>{player2Name}</option>
+                  </select>
+                </div>
+
+                {/* Score */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    Score
+                  </label>
+                  <input
+                    type="text"
+                    value={game.score}
+                    onChange={(e) => handleGameResultChange(game.gameNumber, 'score', e.target.value)}
+                    placeholder="e.g., 2-1"
+                    className="w-full p-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
+                  />
+                </div>
+
+                {/* Duration */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    Duration (minutes)
+                  </label>
+                  <input
+                    type="number"
+                    value={game.duration}
+                    onChange={(e) => handleGameResultChange(game.gameNumber, 'duration', parseInt(e.target.value) || 0)}
+                    min="0"
+                    className="w-full p-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
+                  />
+                </div>
+
+                {/* Notes */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    Notes (optional)
+                  </label>
+                  <input
+                    type="text"
+                    value={game.notes}
+                    onChange={(e) => handleGameResultChange(game.gameNumber, 'notes', e.target.value)}
+                    placeholder="Any special notes"
+                    className="w-full p-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
+                  />
+                </div>
+              </div>
+            </div>
+          ))}
+
+          {/* Submit Button */}
+          <div className="flex justify-end">
+            <button
+              onClick={submitDigitalResults}
+              disabled={isSubmitting || !isCurrentPlayer}
+              className="bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              {isSubmitting ? 'Submitting...' : 'Submit Results'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Paper Result Submission */}
+      {showPaperForm && (
+        <div className="bg-white border border-gray-200 rounded-lg p-4">
+          <h4 className="text-md font-semibold text-gray-900 mb-4">Paper Match Slip Submission</h4>
+          
+          <div className="mb-4">
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              Paper Slip Number
+            </label>
+            <input
+              type="text"
+              value={paperSlipNumber}
+              onChange={(e) => setPaperSlipNumber(e.target.value)}
+              placeholder="Enter the paper slip number"
+              className="w-full p-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
+            />
+          </div>
+
+          <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3 mb-4">
+            <div className="flex items-center">
+              <AlertTriangle className="h-5 w-5 text-yellow-400 mr-2" />
+              <span className="text-sm text-yellow-800">
+                Paper slips will be manually verified by tournament staff. 
+                Please ensure all information is accurate.
+              </span>
+            </div>
+          </div>
+
+          <div className="flex justify-end">
+            <button
+              onClick={submitPaperResults}
+              disabled={isSubmitting || !paperSlipNumber.trim()}
+              className="bg-yellow-600 text-white px-6 py-2 rounded-lg hover:bg-yellow-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              {isSubmitting ? 'Submitting...' : 'Submit Paper Slip'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Match Status */}
+      {matchSlip.status !== 'pending' && (
+        <div className="bg-white border border-gray-200 rounded-lg p-4">
+          <h4 className="text-md font-semibold text-gray-900 mb-2">Match Status</h4>
+          <div className="flex items-center space-x-2">
+            {matchSlip.status === 'completed' ? (
+              <CheckCircle className="h-5 w-5 text-green-500" />
+            ) : matchSlip.status === 'disputed' ? (
+              <XCircle className="h-5 w-5 text-red-500" />
+            ) : (
+              <Clock className="h-5 w-5 text-yellow-500" />
+            )}
+            <span className="text-sm font-medium text-gray-700">
+              Status: {matchSlip.status.charAt(0).toUpperCase() + matchSlip.status.slice(1)}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MatchResultSubmission; 

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -177,6 +177,41 @@ const Profile: React.FC<ProfileProps> = ({ isOwnProfile = true, playerId, active
             </div>
           </div>
 
+          {/* Live Tournament Status - Special for Manraj Sidhu */}
+          {player?.id === 'manraj-sidhu' && player.isActiveInLiveTournament && (
+            <div className="bg-gradient-to-r from-red-50 to-orange-50 border border-red-200 rounded-xl p-4">
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="font-semibold text-red-800">Live Tournament</h3>
+                <span className="px-2 py-1 bg-red-100 text-red-800 rounded-full text-xs font-medium animate-pulse">
+                  Live Now
+                </span>
+              </div>
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-red-700">Tournament:</span>
+                  <span className="font-medium text-red-800">Phoenix Regional Championships</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-red-700">Current Round:</span>
+                  <span className="font-medium text-red-800">Round {player.currentRound}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-red-700">Table:</span>
+                  <span className="font-medium text-red-800">Table {player.currentTable}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-red-700">Opponent:</span>
+                  <span className="font-medium text-red-800">{player.currentMatch?.opponent}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-red-700">Record:</span>
+                  <span className="font-medium text-red-800">{player.currentMatch?.round === 1 ? '0-0' : 
+                    player.currentMatch?.round === 2 ? '1-0' : '2-0'}</span>
+                </div>
+              </div>
+            </div>
+          )}
+
           {/* Favorite Pokémon */}
           <div className="bg-white rounded-xl p-4 border border-gray-200">
             <h3 className="font-semibold text-gray-900 mb-4">Most Used Pokémon</h3>

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -16,6 +16,10 @@ const Profile: React.FC<ProfileProps> = ({ isOwnProfile = true, playerId, active
   const setActiveTab = onTabChange ?? setInternalTab;
   const [isFollowing, setIsFollowing] = useState(false);
   const [publicTeams, setPublicTeams] = useState<TeamShowcaseType[]>([]); // Only public teams
+  const [showDropModal, setShowDropModal] = useState(false);
+  const [dropConfirmText, setDropConfirmText] = useState('');
+  const [dropError, setDropError] = useState<string | null>(null);
+  const [dropped, setDropped] = useState(false);
 
   // Fetch player data if playerId is provided
   const player = playerId ? mockPlayers.find(p => p.id === playerId) : null;
@@ -65,6 +69,17 @@ const Profile: React.FC<ProfileProps> = ({ isOwnProfile = true, playerId, active
     { id: 'achievements' as const, label: 'Achievements' },
     { id: 'history' as const, label: 'History' },
   ];
+
+  // Drop logic
+  const handleDropTournament = () => {
+    if (dropConfirmText.trim().toLowerCase() !== 'phoenix regional championships'.toLowerCase()) {
+      setDropError('Please type the tournament name exactly to confirm.');
+      return;
+    }
+    setDropped(true);
+    setShowDropModal(false);
+    setDropError(null);
+  };
 
   return (
     <div className="px-4 py-6 space-y-6">
@@ -178,7 +193,7 @@ const Profile: React.FC<ProfileProps> = ({ isOwnProfile = true, playerId, active
           </div>
 
           {/* Live Tournament Status - Special for Manraj Sidhu */}
-          {player?.id === 'manraj-sidhu' && player.isActiveInLiveTournament && (
+          {player?.id === 'manraj-sidhu' && player.isActiveInLiveTournament && !dropped && (
             <div className="bg-gradient-to-r from-red-50 to-orange-50 border border-red-200 rounded-xl p-4">
               <div className="flex items-center justify-between mb-3">
                 <h3 className="font-semibold text-red-800">Live Tournament</h3>
@@ -209,6 +224,38 @@ const Profile: React.FC<ProfileProps> = ({ isOwnProfile = true, playerId, active
                     player.currentMatch?.round === 2 ? '1-0' : '2-0'}</span>
                 </div>
               </div>
+              {/* Drop from Tournament Button */}
+              <button
+                className="mt-4 bg-red-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-red-700"
+                onClick={() => setShowDropModal(true)}
+              >
+                Drop from Tournament
+              </button>
+              {showDropModal && (
+                <div className="fixed inset-0 bg-black bg-opacity-40 z-50 flex items-center justify-center">
+                  <div className="bg-white rounded-xl p-6 w-full max-w-md">
+                    <h3 className="text-lg font-semibold mb-4">Confirm Drop from Tournament</h3>
+                    <p className="mb-2 text-gray-700">Type <span className="font-bold">Phoenix Regional Championships</span> to confirm you want to drop from this tournament. This cannot be undone.</p>
+                    <input
+                      type="text"
+                      value={dropConfirmText}
+                      onChange={e => setDropConfirmText(e.target.value)}
+                      placeholder="Type tournament name..."
+                      className="border p-2 rounded w-full mb-2"
+                    />
+                    {dropError && <div className="text-red-600 mb-2">{dropError}</div>}
+                    <div className="flex justify-end space-x-2">
+                      <button onClick={() => setShowDropModal(false)} className="px-4 py-2 rounded bg-gray-200">Cancel</button>
+                      <button onClick={handleDropTournament} className="px-4 py-2 rounded bg-red-600 text-white">Confirm Drop</button>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+          {dropped && (
+            <div className="bg-yellow-100 border border-yellow-200 rounded-xl p-4 text-yellow-800 font-semibold mt-4">
+              You have dropped from the tournament.
             </div>
           )}
 

--- a/src/components/TournamentPairings.tsx
+++ b/src/components/TournamentPairings.tsx
@@ -3,6 +3,7 @@ import { Users, Trophy, Eye, EyeOff, Lock, Calendar, MapPin, Award, Clock, Check
 import { TournamentPairing, Tournament } from '../types';
 import PokemonModal from './PokemonModal';
 import { mockPlayers } from '../data/mockData';
+import TournamentPhoneBanHandler from './TournamentPhoneBanHandler';
 
 interface TournamentPairingsProps {
   tournamentId: string;
@@ -35,6 +36,28 @@ const TournamentPairings: React.FC<TournamentPairingsProps> = ({
 
   // Mock pairings data if not provided
   const pairings: TournamentPairing[] = propPairings || [
+    // Manraj Sidhu's pairings
+    {
+      round: 1,
+      table: 15,
+      player1: { id: 'manraj-sidhu', name: 'Manraj Sidhu', record: '0-0' },
+      player2: { id: 'p1', name: 'Alex Rodriguez', record: '0-0' },
+      result: { winner: 'manraj-sidhu', score: '2-1' }
+    },
+    {
+      round: 2,
+      table: 8,
+      player1: { id: 'manraj-sidhu', name: 'Manraj Sidhu', record: '1-0' },
+      player2: { id: 'p3', name: 'Marcus Johnson', record: '1-0' },
+      result: { winner: 'manraj-sidhu', score: '2-0' }
+    },
+    {
+      round: 3,
+      table: 12,
+      player1: { id: 'manraj-sidhu', name: 'Manraj Sidhu', record: '2-0' },
+      player2: { id: 'p2', name: 'Sarah Chen', record: '2-0' }
+      // No result - current live match
+    },
     {
       round: 1,
       table: 1,
@@ -286,27 +309,69 @@ const TournamentPairings: React.FC<TournamentPairingsProps> = ({
           </div>
         </div>
       </div>
+      {/* Phone Ban Handler */}
+      {tournamentData.status === 'ongoing' && (
+        <TournamentPhoneBanHandler
+          tournamentId={tournamentId}
+          operation="pairing_check"
+          onMethodSelected={(method) => {
+            console.log('Selected pairing check method:', method);
+            // Handle the selected method
+          }}
+        />
+      )}
+
       {/* Cutoff Message */}
       {tournamentData.status === 'completed' && (
         <div className="bg-purple-100 border border-purple-200 rounded-xl p-4 text-center text-purple-800 font-semibold">
           Pairings are now locked. No further results will be posted.
         </div>
       )}
-      {/* Round Selector */}
-      <div className="flex space-x-2 overflow-x-auto pb-2 scrollbar-hide">
-        {rounds.map((round) => (
-          <button
-            key={round}
-            onClick={() => setSelectedRound(round)}
-            className={`px-4 py-3 rounded-full whitespace-nowrap transition-all min-w-fit text-sm sm:text-base ${
-              selectedRound === round
-                ? 'bg-purple-600 text-white shadow-lg'
-                : 'bg-white text-gray-600 hover:bg-gray-50 border border-gray-200'
-            }`}
-          >
-            Round {round}
-          </button>
-        ))}
+      {/* Round Selector and Filters */}
+      <div className="space-y-4">
+        <div className="flex space-x-2 overflow-x-auto pb-2 scrollbar-hide">
+          {rounds.map((round) => (
+            <button
+              key={round}
+              onClick={() => setSelectedRound(round)}
+              className={`px-4 py-3 rounded-full whitespace-nowrap transition-all min-w-fit text-sm sm:text-base ${
+                selectedRound === round
+                  ? 'bg-purple-600 text-white shadow-lg'
+                  : 'bg-white text-gray-600 hover:bg-gray-50 border border-gray-200'
+              }`}
+            >
+              Round {round}
+            </button>
+          ))}
+        </div>
+        
+        {/* Filter Buttons */}
+        <div className="flex flex-wrap gap-2">
+          {currentPlayerId && tournamentData.status === 'ongoing' && (
+            <button
+              onClick={() => setShowMyPairingOnly(!showMyPairingOnly)}
+              className={`px-4 py-2 rounded-full text-sm font-medium transition-all ${
+                showMyPairingOnly
+                  ? 'bg-green-600 text-white shadow-lg'
+                  : 'bg-white text-gray-600 hover:bg-gray-50 border border-gray-200'
+              }`}
+            >
+              {showMyPairingOnly ? 'Show All Pairings' : 'Show My Pairing'}
+            </button>
+          )}
+          {tournamentData.status === 'ongoing' && (
+            <button
+              onClick={() => setShowIncompleteOnly(!showIncompleteOnly)}
+              className={`px-4 py-2 rounded-full text-sm font-medium transition-all ${
+                showIncompleteOnly
+                  ? 'bg-orange-600 text-white shadow-lg'
+                  : 'bg-white text-gray-600 hover:bg-gray-50 border border-gray-200'
+              }`}
+            >
+              {showIncompleteOnly ? 'Show All Matches' : 'Show Incomplete Only'}
+            </button>
+          )}
+        </div>
       </div>
       {/* Pairings Table */}
       <div className="space-y-4">

--- a/src/components/TournamentPhoneBanHandler.tsx
+++ b/src/components/TournamentPhoneBanHandler.tsx
@@ -1,0 +1,216 @@
+import React, { useState, useEffect } from 'react';
+import TournamentPolicyService, { 
+  TournamentOperation, 
+  AlternativeMethod, 
+  CheckInMethod, 
+  ResultSubmissionMethod, 
+  CommunicationMethod 
+} from '../services/TournamentPolicyService';
+
+interface TournamentPhoneBanHandlerProps {
+  tournamentId: string;
+  operation: TournamentOperation;
+  onMethodSelected?: (method: string) => void;
+  showInstructions?: boolean;
+}
+
+const TournamentPhoneBanHandler: React.FC<TournamentPhoneBanHandlerProps> = ({
+  tournamentId,
+  operation,
+  onMethodSelected,
+  showInstructions = true,
+}) => {
+  const [isPhoneBanned, setIsPhoneBanned] = useState(false);
+  const [alternativeMethods, setAlternativeMethods] = useState<AlternativeMethod[]>([]);
+  const [checkInMethods, setCheckInMethods] = useState<CheckInMethod[]>([]);
+  const [resultMethods, setResultMethods] = useState<ResultSubmissionMethod[]>([]);
+  const [communicationMethods, setCommunicationMethods] = useState<CommunicationMethod[]>([]);
+  const [selectedMethod, setSelectedMethod] = useState<string>('');
+
+  useEffect(() => {
+    const checkPhoneBanStatus = () => {
+      const banned = TournamentPolicyService.isPhoneBanned(tournamentId);
+      setIsPhoneBanned(banned);
+      
+      if (banned) {
+        setAlternativeMethods(TournamentPolicyService.getAlternativeMethods(tournamentId, operation));
+        setCheckInMethods(TournamentPolicyService.getCheckInMethods(tournamentId));
+        setResultMethods(TournamentPolicyService.getResultSubmissionMethods(tournamentId));
+        setCommunicationMethods(TournamentPolicyService.getCommunicationMethods(tournamentId));
+      }
+    };
+
+    checkPhoneBanStatus();
+  }, [tournamentId, operation]);
+
+  const handleMethodSelect = (method: string) => {
+    setSelectedMethod(method);
+    onMethodSelected?.(method);
+  };
+
+  const getOperationTitle = (): string => {
+    const titles: Record<TournamentOperation, string> = {
+      'match_reporting': 'Match Result Submission',
+      'pairing_check': 'Check Pairings',
+      'tournament_updates': 'Tournament Updates',
+      'team_verification': 'Team Verification',
+      'dispute_resolution': 'Dispute Resolution',
+    };
+    return titles[operation];
+  };
+
+  const getOperationDescription = (): string => {
+    const descriptions: Record<TournamentOperation, string> = {
+      'match_reporting': 'Submit your match results to the tournament system',
+      'pairing_check': 'Find your next opponent and table assignment',
+      'tournament_updates': 'Get the latest tournament information and announcements',
+      'team_verification': 'Verify your team composition with tournament officials',
+      'dispute_resolution': 'Resolve any issues or disputes during your match',
+    };
+    return descriptions[operation];
+  };
+
+  if (!isPhoneBanned) {
+    return null; // Don't show anything if phones aren't banned
+  }
+
+  return (
+    <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-4">
+      <div className="flex items-center mb-3">
+        <div className="flex-shrink-0">
+          <svg className="h-5 w-5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
+            <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+          </svg>
+        </div>
+        <div className="ml-3">
+          <h3 className="text-sm font-medium text-yellow-800">
+            Phones Banned - Alternative Methods Available
+          </h3>
+        </div>
+      </div>
+
+      <div className="text-sm text-yellow-700 mb-4">
+        <p className="font-medium">{getOperationTitle()}</p>
+        <p className="mt-1">{getOperationDescription()}</p>
+      </div>
+
+      {/* Alternative Methods */}
+      {alternativeMethods.length > 0 && (
+        <div className="mb-4">
+          <h4 className="text-sm font-medium text-yellow-800 mb-2">Available Methods:</h4>
+          <div className="space-y-2">
+            {alternativeMethods.map((method, index) => (
+              <div
+                key={index}
+                className={`p-3 border rounded-lg cursor-pointer transition-colors ${
+                  selectedMethod === method.method
+                    ? 'border-blue-300 bg-blue-50'
+                    : 'border-yellow-200 bg-white hover:bg-yellow-100'
+                }`}
+                onClick={() => handleMethodSelect(method.method)}
+              >
+                <div className="flex items-start justify-between">
+                  <div className="flex-1">
+                    <h5 className="text-sm font-medium text-gray-900">
+                      {method.description}
+                    </h5>
+                    {showInstructions && (
+                      <p className="text-sm text-gray-600 mt-1">
+                        {method.instructions}
+                      </p>
+                    )}
+                    {method.requiresJudge && (
+                      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800 mt-2">
+                        Requires Judge
+                      </span>
+                    )}
+                  </div>
+                  <div className="ml-3">
+                    <input
+                      type="radio"
+                      name="method"
+                      value={method.method}
+                      checked={selectedMethod === method.method}
+                      onChange={() => handleMethodSelect(method.method)}
+                      className="h-4 w-4 text-blue-600 border-gray-300 focus:ring-blue-500"
+                    />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Check-in Methods */}
+      {operation === 'match_reporting' && checkInMethods.length > 0 && (
+        <div className="mb-4">
+          <h4 className="text-sm font-medium text-yellow-800 mb-2">Check-in Methods:</h4>
+          <div className="space-y-2">
+            {checkInMethods.map((method, index) => (
+              <div key={index} className="p-2 bg-white border border-yellow-200 rounded">
+                <p className="text-sm font-medium text-gray-900">{method.description}</p>
+                <p className="text-xs text-gray-600">{method.instructions}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Result Submission Methods */}
+      {operation === 'match_reporting' && resultMethods.length > 0 && (
+        <div className="mb-4">
+          <h4 className="text-sm font-medium text-yellow-800 mb-2">Result Submission:</h4>
+          <div className="space-y-2">
+            {resultMethods.map((method, index) => (
+              <div key={index} className="p-2 bg-white border border-yellow-200 rounded">
+                <p className="text-sm font-medium text-gray-900">{method.description}</p>
+                <p className="text-xs text-gray-600">{method.instructions}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Communication Methods */}
+      {operation === 'tournament_updates' && communicationMethods.length > 0 && (
+        <div className="mb-4">
+          <h4 className="text-sm font-medium text-yellow-800 mb-2">Communication Methods:</h4>
+          <div className="space-y-2">
+            {communicationMethods.map((method, index) => (
+              <div key={index} className="p-2 bg-white border border-yellow-200 rounded">
+                <p className="text-sm font-medium text-gray-900">{method.description}</p>
+                <p className="text-xs text-gray-600">{method.instructions}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* General Instructions */}
+      <div className="bg-white border border-yellow-200 rounded p-3">
+        <h4 className="text-sm font-medium text-yellow-800 mb-2">Important Notes:</h4>
+        <ul className="text-xs text-gray-600 space-y-1">
+          <li>• Phones are not allowed during tournament play</li>
+          <li>• Use the provided alternatives to complete tournament operations</li>
+          <li>• Ask a judge if you need assistance with any method</li>
+          <li>• All results will be manually verified by tournament staff</li>
+        </ul>
+      </div>
+
+      {/* Action Button */}
+      {selectedMethod && (
+        <div className="mt-4">
+          <button
+            onClick={() => onMethodSelected?.(selectedMethod)}
+            className="w-full bg-blue-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            Proceed with Selected Method
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TournamentPhoneBanHandler; 

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -2,6 +2,31 @@ import { Tournament, Player, TournamentPairing } from '../types';
 
 // Comprehensive mock player data across multiple regions
 const mockPlayerData = [
+  // Manraj Sidhu - Active Live Tournament Player
+  {
+    id: 'manraj-sidhu',
+    name: 'Manraj Sidhu',
+    playerId: 'MS2024',
+    region: 'North America',
+    division: 'master',
+    championships: 1,
+    winRate: 75,
+    rating: 1950,
+    isVerified: true,
+    achievements: ['Regional Champion 2023', 'Top 8 Worlds 2023', 'Live Tournament Player'],
+    country: 'Canada',
+    isActiveInLiveTournament: true,
+    currentTournament: 'tournament-1', // Phoenix Regional Championships
+    currentRound: 3,
+    currentTable: 12,
+    currentMatch: {
+      round: 3,
+      table: 12,
+      opponent: 'Sarah Chen',
+      opponentId: 'p2',
+      result: 'pending'
+    }
+  },
   // North America - Top Players
   {
     id: 'p1',

--- a/src/services/AccessibilityService.ts
+++ b/src/services/AccessibilityService.ts
@@ -1,0 +1,743 @@
+import { 
+  AccessibilitySettings, 
+  Theme, 
+  ApiResponse, 
+  AppError 
+} from '../types';
+
+/**
+ * Service for managing accessibility features
+ * Handles screen reader support, keyboard navigation, themes, and other accessibility features
+ */
+export class AccessibilityService {
+  private static instance: AccessibilityService;
+  private currentSettings: AccessibilitySettings;
+  private themes: Map<string, Theme> = new Map();
+  private subscribers: Map<string, (settings: AccessibilitySettings) => void> = new Map();
+  private focusableElements: Set<HTMLElement> = new Set();
+  private currentFocusIndex: number = 0;
+
+  private constructor() {
+    this.initializeDefaultSettings();
+    this.initializeThemes();
+    this.setupKeyboardNavigation();
+    this.setupScreenReaderSupport();
+  }
+
+  static getInstance(): AccessibilityService {
+    if (!AccessibilityService.instance) {
+      AccessibilityService.instance = new AccessibilityService();
+    }
+    return AccessibilityService.instance;
+  }
+
+  /**
+   * Initialize default accessibility settings
+   */
+  private initializeDefaultSettings(): void {
+    this.currentSettings = {
+      screenReader: false,
+      highContrast: false,
+      dyslexiaFriendly: false,
+      fontSize: 'medium',
+      reducedMotion: false,
+      keyboardNavigation: true,
+      colorBlindSupport: false,
+    };
+
+    // Load saved settings from localStorage
+    this.loadSettings();
+  }
+
+  /**
+   * Initialize accessibility themes
+   */
+  private initializeThemes(): void {
+    // Default theme
+    this.themes.set('default', {
+      name: 'Default',
+      colors: {
+        primary: '#3B82F6',
+        secondary: '#6B7280',
+        accent: '#10B981',
+        background: '#FFFFFF',
+        surface: '#F9FAFB',
+        text: '#111827',
+        textSecondary: '#6B7280',
+        border: '#E5E7EB',
+        error: '#EF4444',
+        warning: '#F59E0B',
+        success: '#10B981',
+        info: '#3B82F6',
+      },
+      fonts: {
+        primary: 'Inter, system-ui, sans-serif',
+        secondary: 'Inter, system-ui, sans-serif',
+      },
+      spacing: {
+        xs: '0.25rem',
+        sm: '0.5rem',
+        md: '1rem',
+        lg: '1.5rem',
+        xl: '2rem',
+      },
+      borderRadius: {
+        sm: '0.25rem',
+        md: '0.375rem',
+        lg: '0.5rem',
+        xl: '0.75rem',
+      },
+    });
+
+    // High contrast theme
+    this.themes.set('high-contrast', {
+      name: 'High Contrast',
+      colors: {
+        primary: '#FFFFFF',
+        secondary: '#CCCCCC',
+        accent: '#FFFF00',
+        background: '#000000',
+        surface: '#1A1A1A',
+        text: '#FFFFFF',
+        textSecondary: '#CCCCCC',
+        border: '#FFFFFF',
+        error: '#FF0000',
+        warning: '#FFFF00',
+        success: '#00FF00',
+        info: '#00FFFF',
+      },
+      fonts: {
+        primary: 'Arial, sans-serif',
+        secondary: 'Arial, sans-serif',
+      },
+      spacing: {
+        xs: '0.25rem',
+        sm: '0.5rem',
+        md: '1rem',
+        lg: '1.5rem',
+        xl: '2rem',
+      },
+      borderRadius: {
+        sm: '0.25rem',
+        md: '0.375rem',
+        lg: '0.5rem',
+        xl: '0.75rem',
+      },
+    });
+
+    // Dyslexia-friendly theme
+    this.themes.set('dyslexia-friendly', {
+      name: 'Dyslexia Friendly',
+      colors: {
+        primary: '#2E86AB',
+        secondary: '#A23B72',
+        accent: '#F18F01',
+        background: '#F8F9FA',
+        surface: '#FFFFFF',
+        text: '#2C3E50',
+        textSecondary: '#5A6C7D',
+        border: '#E9ECEF',
+        error: '#E74C3C',
+        warning: '#F39C12',
+        success: '#27AE60',
+        info: '#3498DB',
+      },
+      fonts: {
+        primary: 'OpenDyslexic, Arial, sans-serif',
+        secondary: 'OpenDyslexic, Arial, sans-serif',
+      },
+      spacing: {
+        xs: '0.5rem',
+        sm: '0.75rem',
+        md: '1.25rem',
+        lg: '1.75rem',
+        xl: '2.25rem',
+      },
+      borderRadius: {
+        sm: '0.375rem',
+        md: '0.5rem',
+        lg: '0.75rem',
+        xl: '1rem',
+      },
+    });
+
+    // Color blind friendly theme
+    this.themes.set('colorblind-friendly', {
+      name: 'Color Blind Friendly',
+      colors: {
+        primary: '#1F77B4',
+        secondary: '#FF7F0E',
+        accent: '#2CA02C',
+        background: '#FFFFFF',
+        surface: '#F8F9FA',
+        text: '#2C3E50',
+        textSecondary: '#5A6C7D',
+        border: '#E9ECEF',
+        error: '#D62728',
+        warning: '#9467BD',
+        success: '#8C564B',
+        info: '#E377C2',
+      },
+      fonts: {
+        primary: 'Inter, system-ui, sans-serif',
+        secondary: 'Inter, system-ui, sans-serif',
+      },
+      spacing: {
+        xs: '0.25rem',
+        sm: '0.5rem',
+        md: '1rem',
+        lg: '1.5rem',
+        xl: '2rem',
+      },
+      borderRadius: {
+        sm: '0.25rem',
+        md: '0.375rem',
+        lg: '0.5rem',
+        xl: '0.75rem',
+      },
+    });
+  }
+
+  /**
+   * Setup keyboard navigation
+   */
+  private setupKeyboardNavigation(): void {
+    document.addEventListener('keydown', (event) => {
+      if (!this.currentSettings.keyboardNavigation) return;
+
+      switch (event.key) {
+        case 'Tab':
+          this.handleTabNavigation(event);
+          break;
+        case 'Escape':
+          this.handleEscapeKey(event);
+          break;
+        case 'Enter':
+        case ' ':
+          this.handleEnterKey(event);
+          break;
+        case 'ArrowUp':
+        case 'ArrowDown':
+        case 'ArrowLeft':
+        case 'ArrowRight':
+          this.handleArrowKeys(event);
+          break;
+      }
+    });
+  }
+
+  /**
+   * Setup screen reader support
+   */
+  private setupScreenReaderSupport(): void {
+    if (this.currentSettings.screenReader) {
+      // Add ARIA labels and roles
+      this.addAriaLabels();
+      
+      // Announce dynamic content changes
+      this.setupLiveRegions();
+    }
+  }
+
+  /**
+   * Get current accessibility settings
+   */
+  getSettings(): AccessibilitySettings {
+    return { ...this.currentSettings };
+  }
+
+  /**
+   * Update accessibility settings
+   */
+  async updateSettings(settings: Partial<AccessibilitySettings>): Promise<ApiResponse<AccessibilitySettings>> {
+    try {
+      const newSettings = { ...this.currentSettings, ...settings };
+      
+      // Apply settings
+      await this.applySettings(newSettings);
+      
+      // Save settings
+      this.saveSettings(newSettings);
+      
+      // Notify subscribers
+      this.notifySubscribers(newSettings);
+
+      return {
+        success: true,
+        data: newSettings,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to update accessibility settings', error);
+    }
+  }
+
+  /**
+   * Apply accessibility settings
+   */
+  private async applySettings(settings: AccessibilitySettings): Promise<void> {
+    this.currentSettings = settings;
+
+    // Apply theme
+    if (settings.highContrast) {
+      this.applyTheme('high-contrast');
+    } else if (settings.dyslexiaFriendly) {
+      this.applyTheme('dyslexia-friendly');
+    } else if (settings.colorBlindSupport) {
+      this.applyTheme('colorblind-friendly');
+    } else {
+      this.applyTheme('default');
+    }
+
+    // Apply font size
+    this.applyFontSize(settings.fontSize);
+
+    // Apply reduced motion
+    this.applyReducedMotion(settings.reducedMotion);
+
+    // Apply screen reader support
+    this.applyScreenReaderSupport(settings.screenReader);
+
+    // Apply keyboard navigation
+    this.applyKeyboardNavigation(settings.keyboardNavigation);
+  }
+
+  /**
+   * Apply theme to the document
+   */
+  private applyTheme(themeName: string): void {
+    const theme = this.themes.get(themeName);
+    if (!theme) return;
+
+    const root = document.documentElement;
+    
+    // Apply colors
+    Object.entries(theme.colors).forEach(([key, value]) => {
+      root.style.setProperty(`--color-${key}`, value);
+    });
+
+    // Apply fonts
+    root.style.setProperty('--font-primary', theme.fonts.primary);
+    root.style.setProperty('--font-secondary', theme.fonts.secondary);
+
+    // Apply spacing
+    Object.entries(theme.spacing).forEach(([key, value]) => {
+      root.style.setProperty(`--spacing-${key}`, value);
+    });
+
+    // Apply border radius
+    Object.entries(theme.borderRadius).forEach(([key, value]) => {
+      root.style.setProperty(`--radius-${key}`, value);
+    });
+
+    // Add theme class to body
+    document.body.className = document.body.className
+      .replace(/theme-\w+/g, '')
+      .trim();
+    document.body.classList.add(`theme-${themeName}`);
+  }
+
+  /**
+   * Apply font size
+   */
+  private applyFontSize(size: AccessibilitySettings['fontSize']): void {
+    const root = document.documentElement;
+    const sizeMap = {
+      'small': '0.875rem',
+      'medium': '1rem',
+      'large': '1.125rem',
+      'extra-large': '1.25rem',
+    };
+
+    root.style.setProperty('--font-size-base', sizeMap[size]);
+  }
+
+  /**
+   * Apply reduced motion
+   */
+  private applyReducedMotion(reduced: boolean): void {
+    const root = document.documentElement;
+    if (reduced) {
+      root.style.setProperty('--motion-reduce', '1');
+      document.body.classList.add('motion-reduce');
+    } else {
+      root.style.setProperty('--motion-reduce', '0');
+      document.body.classList.remove('motion-reduce');
+    }
+  }
+
+  /**
+   * Apply screen reader support
+   */
+  private applyScreenReaderSupport(enabled: boolean): void {
+    if (enabled) {
+      this.addAriaLabels();
+      this.setupLiveRegions();
+    } else {
+      this.removeAriaLabels();
+    }
+  }
+
+  /**
+   * Apply keyboard navigation
+   */
+  private applyKeyboardNavigation(enabled: boolean): void {
+    if (enabled) {
+      document.body.classList.add('keyboard-navigation');
+    } else {
+      document.body.classList.remove('keyboard-navigation');
+    }
+  }
+
+  /**
+   * Add ARIA labels to elements
+   */
+  private addAriaLabels(): void {
+    // Add labels to buttons without text
+    document.querySelectorAll('button:not([aria-label]):not([aria-labelledby])').forEach(button => {
+      if (!button.textContent?.trim()) {
+        const icon = button.querySelector('svg, img');
+        if (icon) {
+          button.setAttribute('aria-label', this.getIconDescription(icon));
+        }
+      }
+    });
+
+    // Add labels to form inputs
+    document.querySelectorAll('input:not([aria-label]):not([aria-labelledby])').forEach(input => {
+      const label = document.querySelector(`label[for="${input.id}"]`);
+      if (label) {
+        input.setAttribute('aria-labelledby', label.id);
+      }
+    });
+
+    // Add roles to interactive elements
+    document.querySelectorAll('[role]').forEach(element => {
+      // Ensure proper ARIA attributes for roles
+      const role = element.getAttribute('role');
+      switch (role) {
+        case 'button':
+          if (!element.hasAttribute('tabindex')) {
+            element.setAttribute('tabindex', '0');
+          }
+          break;
+        case 'tab':
+          if (!element.hasAttribute('aria-selected')) {
+            element.setAttribute('aria-selected', 'false');
+          }
+          break;
+      }
+    });
+  }
+
+  /**
+   * Remove ARIA labels
+   */
+  private removeAriaLabels(): void {
+    // Remove custom ARIA labels added by this service
+    document.querySelectorAll('[data-accessibility-added]').forEach(element => {
+      element.removeAttribute('aria-label');
+      element.removeAttribute('data-accessibility-added');
+    });
+  }
+
+  /**
+   * Setup live regions for dynamic content
+   */
+  private setupLiveRegions(): void {
+    // Create live region for announcements
+    let liveRegion = document.getElementById('accessibility-live-region');
+    if (!liveRegion) {
+      liveRegion = document.createElement('div');
+      liveRegion.id = 'accessibility-live-region';
+      liveRegion.setAttribute('aria-live', 'polite');
+      liveRegion.setAttribute('aria-atomic', 'true');
+      liveRegion.style.position = 'absolute';
+      liveRegion.style.left = '-10000px';
+      liveRegion.style.width = '1px';
+      liveRegion.style.height = '1px';
+      liveRegion.style.overflow = 'hidden';
+      document.body.appendChild(liveRegion);
+    }
+  }
+
+  /**
+   * Announce message to screen readers
+   */
+  announce(message: string, priority: 'polite' | 'assertive' = 'polite'): void {
+    if (!this.currentSettings.screenReader) return;
+
+    const liveRegion = document.getElementById('accessibility-live-region');
+    if (liveRegion) {
+      liveRegion.setAttribute('aria-live', priority);
+      liveRegion.textContent = message;
+      
+      // Clear the message after a short delay
+      setTimeout(() => {
+        liveRegion.textContent = '';
+      }, 1000);
+    }
+  }
+
+  /**
+   * Handle tab navigation
+   */
+  private handleTabNavigation(event: KeyboardEvent): void {
+    const focusableElements = this.getFocusableElements();
+    
+    if (focusableElements.length === 0) return;
+
+    if (event.shiftKey) {
+      // Shift+Tab: move backwards
+      event.preventDefault();
+      this.currentFocusIndex = this.currentFocusIndex > 0 
+        ? this.currentFocusIndex - 1 
+        : focusableElements.length - 1;
+    } else {
+      // Tab: move forwards
+      event.preventDefault();
+      this.currentFocusIndex = this.currentFocusIndex < focusableElements.length - 1 
+        ? this.currentFocusIndex + 1 
+        : 0;
+    }
+
+    focusableElements[this.currentFocusIndex]?.focus();
+  }
+
+  /**
+   * Handle escape key
+   */
+  private handleEscapeKey(event: KeyboardEvent): void {
+    // Close modals, dropdowns, etc.
+    const activeElement = document.activeElement;
+    if (activeElement && activeElement.getAttribute('role') === 'dialog') {
+      const closeButton = activeElement.querySelector('[aria-label*="close"], [aria-label*="Close"]');
+      if (closeButton) {
+        (closeButton as HTMLElement).click();
+      }
+    }
+  }
+
+  /**
+   * Handle enter key
+   */
+  private handleEnterKey(event: KeyboardEvent): void {
+    const target = event.target as HTMLElement;
+    
+    if (target.getAttribute('role') === 'button' || target.tagName === 'BUTTON') {
+      event.preventDefault();
+      target.click();
+    }
+  }
+
+  /**
+   * Handle arrow keys
+   */
+  private handleArrowKeys(event: KeyboardEvent): void {
+    const target = event.target as HTMLElement;
+    
+    // Handle arrow keys for custom components
+    if (target.getAttribute('role') === 'tab') {
+      this.handleTabArrowKeys(event);
+    } else if (target.getAttribute('role') === 'listbox') {
+      this.handleListboxArrowKeys(event);
+    }
+  }
+
+  /**
+   * Handle arrow keys for tabs
+   */
+  private handleTabArrowKeys(event: KeyboardEvent): void {
+    const tabs = Array.from(document.querySelectorAll('[role="tab"]'));
+    const currentIndex = tabs.indexOf(event.target as HTMLElement);
+    
+    if (currentIndex === -1) return;
+
+    let newIndex: number;
+    
+    if (event.key === 'ArrowLeft') {
+      newIndex = currentIndex > 0 ? currentIndex - 1 : tabs.length - 1;
+    } else if (event.key === 'ArrowRight') {
+      newIndex = currentIndex < tabs.length - 1 ? currentIndex + 1 : 0;
+    } else {
+      return;
+    }
+
+    event.preventDefault();
+    (tabs[newIndex] as HTMLElement).focus();
+    (tabs[newIndex] as HTMLElement).click();
+  }
+
+  /**
+   * Handle arrow keys for listboxes
+   */
+  private handleListboxArrowKeys(event: KeyboardEvent): void {
+    const options = Array.from(document.querySelectorAll('[role="option"]'));
+    const currentIndex = options.indexOf(event.target as HTMLElement);
+    
+    if (currentIndex === -1) return;
+
+    let newIndex: number;
+    
+    if (event.key === 'ArrowUp') {
+      newIndex = currentIndex > 0 ? currentIndex - 1 : options.length - 1;
+    } else if (event.key === 'ArrowDown') {
+      newIndex = currentIndex < options.length - 1 ? currentIndex + 1 : 0;
+    } else {
+      return;
+    }
+
+    event.preventDefault();
+    (options[newIndex] as HTMLElement).focus();
+    (options[newIndex] as HTMLElement).click();
+  }
+
+  /**
+   * Get all focusable elements
+   */
+  private getFocusableElements(): HTMLElement[] {
+    const focusableSelectors = [
+      'button:not([disabled])',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      'textarea:not([disabled])',
+      'a[href]',
+      '[tabindex]:not([tabindex="-1"])',
+      '[role="button"]',
+      '[role="tab"]',
+      '[role="option"]',
+    ];
+
+    return Array.from(document.querySelectorAll(focusableSelectors.join(','))) as HTMLElement[];
+  }
+
+  /**
+   * Get icon description for ARIA labels
+   */
+  private getIconDescription(icon: Element): string {
+    // This would be a comprehensive mapping of icons to descriptions
+    const iconDescriptions: { [key: string]: string } = {
+      'home': 'Go to home page',
+      'settings': 'Open settings',
+      'close': 'Close',
+      'menu': 'Open menu',
+      'search': 'Search',
+      'notifications': 'Notifications',
+      'profile': 'User profile',
+      'logout': 'Log out',
+      'edit': 'Edit',
+      'delete': 'Delete',
+      'save': 'Save',
+      'cancel': 'Cancel',
+      'add': 'Add',
+      'remove': 'Remove',
+      'play': 'Play',
+      'pause': 'Pause',
+      'stop': 'Stop',
+      'next': 'Next',
+      'previous': 'Previous',
+    };
+
+    // Try to get description from icon class or data attribute
+    const className = icon.className.baseVal || icon.className;
+    const dataDescription = icon.getAttribute('data-description');
+    
+    if (dataDescription) {
+      return dataDescription;
+    }
+
+    // Try to match class name
+    for (const [key, description] of Object.entries(iconDescriptions)) {
+      if (className.includes(key)) {
+        return description;
+      }
+    }
+
+    return 'Icon';
+  }
+
+  /**
+   * Subscribe to settings changes
+   */
+  subscribe(callback: (settings: AccessibilitySettings) => void): string {
+    const subscriptionId = this.generateId();
+    this.subscribers.set(subscriptionId, callback);
+    return subscriptionId;
+  }
+
+  /**
+   * Unsubscribe from settings changes
+   */
+  unsubscribe(subscriptionId: string): boolean {
+    return this.subscribers.delete(subscriptionId);
+  }
+
+  /**
+   * Notify subscribers of settings changes
+   */
+  private notifySubscribers(settings: AccessibilitySettings): void {
+    this.subscribers.forEach(callback => {
+      try {
+        callback(settings);
+      } catch (error) {
+        console.error('Error in accessibility subscriber:', error);
+      }
+    });
+  }
+
+  /**
+   * Load settings from localStorage
+   */
+  private loadSettings(): void {
+    try {
+      const saved = localStorage.getItem('accessibility-settings');
+      if (saved) {
+        const parsed = JSON.parse(saved);
+        this.currentSettings = { ...this.currentSettings, ...parsed };
+        this.applySettings(this.currentSettings);
+      }
+    } catch (error) {
+      console.error('Failed to load accessibility settings:', error);
+    }
+  }
+
+  /**
+   * Save settings to localStorage
+   */
+  private saveSettings(settings: AccessibilitySettings): void {
+    try {
+      localStorage.setItem('accessibility-settings', JSON.stringify(settings));
+    } catch (error) {
+      console.error('Failed to save accessibility settings:', error);
+    }
+  }
+
+  /**
+   * Generate unique ID
+   */
+  private generateId(): string {
+    return Math.random().toString(36).substr(2, 9);
+  }
+
+  /**
+   * Handle errors
+   */
+  private handleError(message: string, error: any): ApiResponse<any> {
+    const appError: AppError = {
+      code: 'ACCESSIBILITY_ERROR',
+      message,
+      details: error.message,
+      timestamp: new Date().toISOString(),
+    };
+
+    return {
+      success: false,
+      error: message,
+      timestamp: new Date().toISOString(),
+      requestId: this.generateId(),
+    };
+  }
+}
+
+export default AccessibilityService.getInstance(); 

--- a/src/services/MatchSlipService.ts
+++ b/src/services/MatchSlipService.ts
@@ -1,0 +1,605 @@
+import { 
+  MatchSlip, 
+  GameResult, 
+  DigitalSignature, 
+  Dispute, 
+  AuditEntry, 
+  DeviceInfo,
+  ApiResponse,
+  AppError 
+} from '../types';
+
+/**
+ * Service for managing digital match slips in VGC tournaments
+ * Handles game results, digital signatures, disputes, and audit trails
+ * Note: Phones are banned during tournament play, so mobile features are disabled during live matches
+ */
+export class MatchSlipService {
+  private static instance: MatchSlipService;
+  private matchSlips: Map<string, MatchSlip> = new Map();
+  private auditTrail: AuditEntry[] = [];
+  private tournamentPhoneBans: Set<string> = new Set(); // Track tournaments with phone bans
+
+  private constructor() {}
+
+  static getInstance(): MatchSlipService {
+    if (!MatchSlipService.instance) {
+      MatchSlipService.instance = new MatchSlipService();
+    }
+    return MatchSlipService.instance;
+  }
+
+  /**
+   * Enable phone ban for a tournament
+   */
+  enablePhoneBan(tournamentId: string): void {
+    this.tournamentPhoneBans.add(tournamentId);
+  }
+
+  /**
+   * Disable phone ban for a tournament
+   */
+  disablePhoneBan(tournamentId: string): void {
+    this.tournamentPhoneBans.delete(tournamentId);
+  }
+
+  /**
+   * Check if phones are banned for a tournament
+   */
+  isPhoneBanned(tournamentId: string): boolean {
+    return this.tournamentPhoneBans.has(tournamentId);
+  }
+
+  /**
+   * Create a new match slip for a tournament match
+   */
+  async createMatchSlip(
+    tournamentId: string,
+    round: number,
+    table: number,
+    player1Id: string,
+    player1Name: string,
+    player2Id: string,
+    player2Name: string
+  ): Promise<ApiResponse<MatchSlip>> {
+    try {
+      const isPhoneBanned = this.isPhoneBanned(tournamentId);
+      
+      const matchSlip: MatchSlip = {
+        id: this.generateId(),
+        tournamentId,
+        round,
+        table,
+        player1Id,
+        player1Name,
+        player2Id,
+        player2Name,
+        games: [],
+        status: 'pending',
+        auditTrail: [],
+        qrCode: isPhoneBanned ? null : this.generateQRCode(), // No QR codes if phones banned
+        qrCodeExpiresAt: isPhoneBanned ? null : new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        phoneBanned: isPhoneBanned,
+      };
+
+      this.matchSlips.set(matchSlip.id, matchSlip);
+      this.addAuditEntry(matchSlip.id, 'match_slip_created', 'system', 
+        `Match slip created${isPhoneBanned ? ' (phones banned)' : ''}`);
+
+      return {
+        success: true,
+        data: matchSlip,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to create match slip', error);
+    }
+  }
+
+  /**
+   * Submit game results for a match
+   */
+  async submitGameResult(
+    matchSlipId: string,
+    gameNumber: number,
+    winnerId: string,
+    score: string,
+    duration: number,
+    submittedBy: string,
+    notes?: string
+  ): Promise<ApiResponse<GameResult>> {
+    try {
+      const matchSlip = this.matchSlips.get(matchSlipId);
+      if (!matchSlip) {
+        throw new Error('Match slip not found');
+      }
+
+      if (matchSlip.status === 'completed') {
+        throw new Error('Match slip is already completed');
+      }
+
+      const gameResult: GameResult = {
+        gameNumber,
+        winnerId,
+        score,
+        duration,
+        notes,
+        submittedBy,
+        submittedAt: new Date().toISOString(),
+      };
+
+      matchSlip.games.push(gameResult);
+      matchSlip.status = 'in-progress';
+
+      // Update final score and winner if all games are complete
+      this.updateMatchResult(matchSlip);
+
+      this.addAuditEntry(matchSlipId, 'game_result_submitted', submittedBy, `Game ${gameNumber} result submitted`);
+
+      return {
+        success: true,
+        data: gameResult,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to submit game result', error);
+    }
+  }
+
+  /**
+   * Submit digital signature for a match slip
+   * Note: Touch signatures are disabled during phone bans
+   */
+  async submitSignature(
+    matchSlipId: string,
+    playerId: string,
+    signatureType: 'touch' | 'pin' | 'digital',
+    signatureData: string,
+    deviceInfo: DeviceInfo
+  ): Promise<ApiResponse<DigitalSignature>> {
+    try {
+      const matchSlip = this.matchSlips.get(matchSlipId);
+      if (!matchSlip) {
+        throw new Error('Match slip not found');
+      }
+
+      if (matchSlip.player1Id !== playerId && matchSlip.player2Id !== playerId) {
+        throw new Error('Player not authorized to sign this match slip');
+      }
+
+      // Check phone ban restrictions
+      if (matchSlip.phoneBanned && signatureType === 'touch') {
+        throw new Error('Touch signatures are not allowed during tournament play due to phone bans');
+      }
+
+      // Check if device is mobile during phone ban
+      if (matchSlip.phoneBanned && this.isMobileDevice(deviceInfo)) {
+        throw new Error('Mobile devices are not allowed during tournament play');
+      }
+
+      const signature: DigitalSignature = {
+        playerId,
+        signatureType,
+        signatureData,
+        timestamp: new Date().toISOString(),
+        deviceInfo,
+      };
+
+      if (matchSlip.player1Id === playerId) {
+        matchSlip.player1Signature = signature;
+      } else {
+        matchSlip.player2Signature = signature;
+      }
+
+      // Check if both players have signed
+      if (matchSlip.player1Signature && matchSlip.player2Signature) {
+        matchSlip.status = 'completed';
+        matchSlip.submittedAt = new Date().toISOString();
+      }
+
+      this.addAuditEntry(matchSlipId, 'signature_submitted', playerId, 
+        `${signatureType} signature submitted${matchSlip.phoneBanned ? ' (non-mobile)' : ''}`);
+
+      return {
+        success: true,
+        data: signature,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to submit signature', error);
+    }
+  }
+
+  /**
+   * Submit paper-based match slip (alternative to digital when phones are banned)
+   */
+  async submitPaperMatchSlip(
+    matchSlipId: string,
+    submittedBy: string,
+    paperSlipNumber: string,
+    judgeSignature?: string
+  ): Promise<ApiResponse<MatchSlip>> {
+    try {
+      const matchSlip = this.matchSlips.get(matchSlipId);
+      if (!matchSlip) {
+        throw new Error('Match slip not found');
+      }
+
+      if (!matchSlip.phoneBanned) {
+        throw new Error('Paper match slips are only allowed when phones are banned');
+      }
+
+      // Create a special signature for paper submission
+      const paperSignature: DigitalSignature = {
+        playerId: submittedBy,
+        signatureType: 'digital',
+        signatureData: `PAPER_SLIP_${paperSlipNumber}`,
+        timestamp: new Date().toISOString(),
+        deviceInfo: {
+          userAgent: 'Paper Match Slip',
+          screenResolution: 'N/A',
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          language: navigator.language,
+        },
+      };
+
+      if (matchSlip.player1Id === submittedBy) {
+        matchSlip.player1Signature = paperSignature;
+      } else if (matchSlip.player2Id === submittedBy) {
+        matchSlip.player2Signature = paperSignature;
+      } else {
+        throw new Error('Player not authorized to submit this match slip');
+      }
+
+      // If judge signature is provided, mark as completed
+      if (judgeSignature) {
+        matchSlip.status = 'completed';
+        matchSlip.submittedAt = new Date().toISOString();
+        matchSlip.reviewedBy = 'judge';
+        matchSlip.reviewedAt = new Date().toISOString();
+      }
+
+      this.addAuditEntry(matchSlipId, 'paper_slip_submitted', submittedBy, 
+        `Paper match slip ${paperSlipNumber} submitted${judgeSignature ? ' (judge verified)' : ''}`);
+
+      return {
+        success: true,
+        data: matchSlip,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to submit paper match slip', error);
+    }
+  }
+
+  /**
+   * Get match slip by QR code (disabled during phone bans)
+   */
+  async getMatchSlipByQRCode(qrCode: string): Promise<ApiResponse<MatchSlip>> {
+    try {
+      const matchSlip = Array.from(this.matchSlips.values()).find(
+        slip => slip.qrCode === qrCode && slip.qrCodeExpiresAt > new Date().toISOString()
+      );
+
+      if (!matchSlip) {
+        throw new Error('Match slip not found or QR code expired');
+      }
+
+      if (matchSlip.phoneBanned) {
+        throw new Error('QR code access is disabled during tournament play due to phone bans');
+      }
+
+      return {
+        success: true,
+        data: matchSlip,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to get match slip by QR code', error);
+    }
+  }
+
+  /**
+   * Get match slip by table number (alternative when phones are banned)
+   */
+  async getMatchSlipByTable(
+    tournamentId: string,
+    round: number,
+    table: number
+  ): Promise<ApiResponse<MatchSlip>> {
+    try {
+      const matchSlip = Array.from(this.matchSlips.values()).find(
+        slip => slip.tournamentId === tournamentId && 
+               slip.round === round && 
+               slip.table === table
+      );
+
+      if (!matchSlip) {
+        throw new Error('Match slip not found for this table');
+      }
+
+      return {
+        success: true,
+        data: matchSlip,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to get match slip by table', error);
+    }
+  }
+
+  /**
+   * Get available signature methods for a match slip
+   */
+  getAvailableSignatureMethods(matchSlipId: string): string[] {
+    const matchSlip = this.matchSlips.get(matchSlipId);
+    if (!matchSlip) return [];
+
+    if (matchSlip.phoneBanned) {
+      return ['pin', 'digital']; // No touch signatures during phone bans
+    } else {
+      return ['touch', 'pin', 'digital'];
+    }
+  }
+
+  /**
+   * Check if device is mobile
+   */
+  private isMobileDevice(deviceInfo: DeviceInfo): boolean {
+    const mobileKeywords = ['mobile', 'android', 'iphone', 'ipad', 'phone'];
+    return mobileKeywords.some(keyword => 
+      deviceInfo.userAgent.toLowerCase().includes(keyword)
+    );
+  }
+
+  /**
+   * Get match slip by ID
+   */
+  async getMatchSlip(matchSlipId: string): Promise<ApiResponse<MatchSlip>> {
+    try {
+      const matchSlip = this.matchSlips.get(matchSlipId);
+      if (!matchSlip) {
+        throw new Error('Match slip not found');
+      }
+
+      return {
+        success: true,
+        data: matchSlip,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to get match slip', error);
+    }
+  }
+
+  /**
+   * Get match slips for a tournament
+   */
+  async getTournamentMatchSlips(tournamentId: string): Promise<ApiResponse<MatchSlip[]>> {
+    try {
+      const matchSlips = Array.from(this.matchSlips.values()).filter(
+        slip => slip.tournamentId === tournamentId
+      );
+
+      return {
+        success: true,
+        data: matchSlips,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to get tournament match slips', error);
+    }
+  }
+
+  /**
+   * Get match slips for a player
+   */
+  async getPlayerMatchSlips(playerId: string): Promise<ApiResponse<MatchSlip[]>> {
+    try {
+      const matchSlips = Array.from(this.matchSlips.values()).filter(
+        slip => slip.player1Id === playerId || slip.player2Id === playerId
+      );
+
+      return {
+        success: true,
+        data: matchSlips,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to get player match slips', error);
+    }
+  }
+
+  /**
+   * Get audit trail for a match slip
+   */
+  async getAuditTrail(matchSlipId: string): Promise<ApiResponse<AuditEntry[]>> {
+    try {
+      const matchSlip = this.matchSlips.get(matchSlipId);
+      if (!matchSlip) {
+        throw new Error('Match slip not found');
+      }
+
+      return {
+        success: true,
+        data: matchSlip.auditTrail,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to get audit trail', error);
+    }
+  }
+
+  /**
+   * Raise a dispute for a match slip
+   */
+  async raiseDispute(
+    matchSlipId: string,
+    raisedBy: string,
+    reason: string,
+    description: string,
+    evidence?: string[]
+  ): Promise<ApiResponse<Dispute>> {
+    try {
+      const matchSlip = this.matchSlips.get(matchSlipId);
+      if (!matchSlip) {
+        throw new Error('Match slip not found');
+      }
+
+      if (matchSlip.player1Id !== raisedBy && matchSlip.player2Id !== raisedBy) {
+        throw new Error('Player not authorized to raise dispute');
+      }
+
+      const dispute: Dispute = {
+        id: this.generateId(),
+        raisedBy,
+        reason,
+        description,
+        evidence,
+        status: 'open',
+        createdAt: new Date().toISOString(),
+      };
+
+      matchSlip.dispute = dispute;
+      matchSlip.status = 'disputed';
+
+      this.addAuditEntry(matchSlipId, 'dispute_raised', raisedBy, `Dispute raised: ${reason}`);
+
+      return {
+        success: true,
+        data: dispute,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to raise dispute', error);
+    }
+  }
+
+  /**
+   * Resolve a dispute
+   */
+  async resolveDispute(
+    matchSlipId: string,
+    judgeId: string,
+    resolution: string
+  ): Promise<ApiResponse<Dispute>> {
+    try {
+      const matchSlip = this.matchSlips.get(matchSlipId);
+      if (!matchSlip || !matchSlip.dispute) {
+        throw new Error('Dispute not found');
+      }
+
+      matchSlip.dispute.status = 'resolved';
+      matchSlip.dispute.assignedJudge = judgeId;
+      matchSlip.dispute.resolution = resolution;
+      matchSlip.dispute.resolvedAt = new Date().toISOString();
+
+      matchSlip.status = 'resolved';
+      matchSlip.reviewedBy = judgeId;
+      matchSlip.reviewedAt = new Date().toISOString();
+
+      this.addAuditEntry(matchSlipId, 'dispute_resolved', judgeId, `Dispute resolved: ${resolution}`);
+
+      return {
+        success: true,
+        data: matchSlip.dispute,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to resolve dispute', error);
+    }
+  }
+
+  /**
+   * Update match result based on game results
+   */
+  private updateMatchResult(matchSlip: MatchSlip): void {
+    if (matchSlip.games.length === 0) return;
+
+    const player1Wins = matchSlip.games.filter(game => game.winnerId === matchSlip.player1Id).length;
+    const player2Wins = matchSlip.games.filter(game => game.winnerId === matchSlip.player2Id).length;
+
+    if (player1Wins > player2Wins) {
+      matchSlip.winnerId = matchSlip.player1Id;
+      matchSlip.finalScore = `${player1Wins}-${player2Wins}`;
+    } else if (player2Wins > player1Wins) {
+      matchSlip.winnerId = matchSlip.player2Id;
+      matchSlip.finalScore = `${player2Wins}-${player1Wins}`;
+    } else {
+      // Handle draws if needed
+      matchSlip.finalScore = `${player1Wins}-${player2Wins}`;
+    }
+  }
+
+  /**
+   * Add audit entry
+   */
+  private addAuditEntry(
+    matchSlipId: string,
+    action: string,
+    userId: string,
+    details: string
+  ): void {
+    const auditEntry: AuditEntry = {
+      id: this.generateId(),
+      action,
+      userId,
+      timestamp: new Date().toISOString(),
+      details,
+    };
+
+    const matchSlip = this.matchSlips.get(matchSlipId);
+    if (matchSlip) {
+      matchSlip.auditTrail.push(auditEntry);
+    }
+
+    this.auditTrail.push(auditEntry);
+  }
+
+  /**
+   * Generate unique ID
+   */
+  private generateId(): string {
+    return Math.random().toString(36).substr(2, 9);
+  }
+
+  /**
+   * Generate QR code
+   */
+  private generateQRCode(): string {
+    return `MS-${Date.now()}-${Math.random().toString(36).substr(2, 6)}`;
+  }
+
+  /**
+   * Handle errors
+   */
+  private handleError(message: string, error: any): ApiResponse<any> {
+    const appError: AppError = {
+      code: 'MATCH_SLIP_ERROR',
+      message,
+      details: error.message,
+      timestamp: new Date().toISOString(),
+    };
+
+    return {
+      success: false,
+      error: message,
+      timestamp: new Date().toISOString(),
+      requestId: this.generateId(),
+    };
+  }
+}
+
+export default MatchSlipService.getInstance(); 

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -1,0 +1,670 @@
+import { 
+  Notification, 
+  TournamentNotification, 
+  CalendarEvent, 
+  CalendarReminder,
+  ApiResponse,
+  AppError,
+  UserSession
+} from '../types';
+
+/**
+ * Service for managing notifications across different channels
+ * Handles push notifications, email, SMS, and in-app notifications
+ */
+export class NotificationService {
+  private static instance: NotificationService;
+  private notifications: Map<string, Notification> = new Map();
+  private subscribers: Map<string, (notification: Notification) => void> = new Map();
+  private pushSubscription: PushSubscription | null = null;
+
+  private constructor() {
+    this.initializeServiceWorker();
+  }
+
+  static getInstance(): NotificationService {
+    if (!NotificationService.instance) {
+      NotificationService.instance = new NotificationService();
+    }
+    return NotificationService.instance;
+  }
+
+  /**
+   * Initialize service worker for push notifications
+   */
+  private async initializeServiceWorker(): Promise<void> {
+    if ('serviceWorker' in navigator && 'PushManager' in window) {
+      try {
+        const registration = await navigator.serviceWorker.register('/sw.js');
+        console.log('Service Worker registered:', registration);
+      } catch (error) {
+        console.error('Service Worker registration failed:', error);
+      }
+    }
+  }
+
+  /**
+   * Request push notification permission and subscribe
+   */
+  async requestPushPermission(): Promise<ApiResponse<boolean>> {
+    try {
+      if (!('Notification' in window)) {
+        throw new Error('Push notifications not supported');
+      }
+
+      const permission = await Notification.requestPermission();
+      if (permission === 'granted') {
+        await this.subscribeToPushNotifications();
+        return {
+          success: true,
+          data: true,
+          timestamp: new Date().toISOString(),
+          requestId: this.generateId(),
+        };
+      } else {
+        throw new Error('Push notification permission denied');
+      }
+    } catch (error) {
+      return this.handleError('Failed to request push permission', error);
+    }
+  }
+
+  /**
+   * Subscribe to push notifications
+   */
+  private async subscribeToPushNotifications(): Promise<void> {
+    try {
+      const registration = await navigator.serviceWorker.ready;
+      const subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: this.urlBase64ToUint8Array(process.env.VAPID_PUBLIC_KEY || ''),
+      });
+
+      this.pushSubscription = subscription;
+      console.log('Push notification subscription:', subscription);
+    } catch (error) {
+      console.error('Failed to subscribe to push notifications:', error);
+    }
+  }
+
+  /**
+   * Create a new notification
+   */
+  async createNotification(
+    userId: string,
+    type: Notification['type'],
+    title: string,
+    message: string,
+    priority: Notification['priority'] = 'medium',
+    data?: any,
+    actionUrl?: string,
+    expiresAt?: string
+  ): Promise<ApiResponse<Notification>> {
+    try {
+      const notification: Notification = {
+        id: this.generateId(),
+        userId,
+        type,
+        title,
+        message,
+        data,
+        isRead: false,
+        createdAt: new Date().toISOString(),
+        expiresAt,
+        actionUrl,
+        priority,
+      };
+
+      this.notifications.set(notification.id, notification);
+
+      // Send to all channels based on user preferences
+      await this.sendToChannels(notification);
+
+      // Notify subscribers
+      this.notifySubscribers(notification);
+
+      return {
+        success: true,
+        data: notification,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to create notification', error);
+    }
+  }
+
+  /**
+   * Create tournament-specific notification
+   */
+  async createTournamentNotification(
+    userId: string,
+    tournamentId: string,
+    title: string,
+    message: string,
+    round?: number,
+    table?: number,
+    actionRequired: boolean = false,
+    priority: Notification['priority'] = 'medium'
+  ): Promise<ApiResponse<TournamentNotification>> {
+    try {
+      const notification: TournamentNotification = {
+        id: this.generateId(),
+        userId,
+        type: 'tournament',
+        title,
+        message,
+        tournamentId,
+        round,
+        table,
+        actionRequired,
+        isRead: false,
+        createdAt: new Date().toISOString(),
+        priority,
+      };
+
+      this.notifications.set(notification.id, notification);
+
+      // Send to all channels
+      await this.sendToChannels(notification);
+
+      // Notify subscribers
+      this.notifySubscribers(notification);
+
+      return {
+        success: true,
+        data: notification,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to create tournament notification', error);
+    }
+  }
+
+  /**
+   * Send notification to all channels
+   */
+  private async sendToChannels(notification: Notification): Promise<void> {
+    // In-app notification (always sent)
+    this.sendInAppNotification(notification);
+
+    // Check if this is a tournament notification during phone ban
+    const isTournamentDuringPhoneBan = this.isTournamentDuringPhoneBan(notification);
+
+    // Push notification (disabled during phone bans for tournament notifications)
+    if (this.pushSubscription && notification.priority !== 'low' && !isTournamentDuringPhoneBan) {
+      await this.sendPushNotification(notification);
+    }
+
+    // Email notification (for high priority or action required)
+    if (notification.priority === 'high' || notification.priority === 'urgent') {
+      await this.sendEmailNotification(notification);
+    }
+
+    // SMS notification (for urgent only, but not during phone bans)
+    if (notification.priority === 'urgent' && !isTournamentDuringPhoneBan) {
+      await this.sendSMSNotification(notification);
+    }
+  }
+
+  /**
+   * Check if notification is for a tournament during phone ban
+   */
+  private isTournamentDuringPhoneBan(notification: Notification): boolean {
+    if (notification.type !== 'tournament') return false;
+    
+    // This would check against the tournament's phone ban status
+    // For now, we'll assume all tournament notifications during live play have phone bans
+    const tournamentNotification = notification as TournamentNotification;
+    return tournamentNotification.actionRequired === true;
+  }
+
+  /**
+   * Send in-app notification
+   */
+  private sendInAppNotification(notification: Notification): void {
+    // This would trigger a UI update in the app
+    console.log('In-app notification:', notification);
+  }
+
+  /**
+   * Send push notification
+   */
+  private async sendPushNotification(notification: Notification): Promise<void> {
+    try {
+      if (this.pushSubscription) {
+        const payload = {
+          title: notification.title,
+          body: notification.message,
+          icon: '/icon-192.png',
+          badge: '/icon-192.png',
+          data: {
+            notificationId: notification.id,
+            actionUrl: notification.actionUrl,
+            type: notification.type,
+          },
+          actions: notification.actionUrl ? [
+            {
+              action: 'open',
+              title: 'Open',
+              icon: '/icon-192.png',
+            },
+            {
+              action: 'dismiss',
+              title: 'Dismiss',
+            },
+          ] : undefined,
+        };
+
+        // In a real implementation, this would be sent to your server
+        // which would then send it to the push service
+        console.log('Push notification payload:', payload);
+      }
+    } catch (error) {
+      console.error('Failed to send push notification:', error);
+    }
+  }
+
+  /**
+   * Send email notification
+   */
+  private async sendEmailNotification(notification: Notification): Promise<void> {
+    try {
+      // This would integrate with an email service like SendGrid, Mailgun, etc.
+      const emailData = {
+        to: notification.userId, // This would be the user's email
+        subject: notification.title,
+        body: notification.message,
+        template: this.getEmailTemplate(notification.type),
+        data: notification.data,
+      };
+
+      console.log('Email notification:', emailData);
+    } catch (error) {
+      console.error('Failed to send email notification:', error);
+    }
+  }
+
+  /**
+   * Send SMS notification
+   */
+  private async sendSMSNotification(notification: Notification): Promise<void> {
+    try {
+      // This would integrate with an SMS service like Twilio
+      const smsData = {
+        to: notification.userId, // This would be the user's phone number
+        message: `${notification.title}: ${notification.message}`,
+      };
+
+      console.log('SMS notification:', smsData);
+    } catch (error) {
+      console.error('Failed to send SMS notification:', error);
+    }
+  }
+
+  /**
+   * Get email template for notification type
+   */
+  private getEmailTemplate(type: Notification['type']): string {
+    const templates: { [key: string]: string } = {
+      'tournament': 'tournament-notification',
+      'pairing': 'pairing-notification',
+      'social': 'social-notification',
+      'system': 'system-notification',
+      'achievement': 'achievement-notification',
+    };
+
+    return templates[type] || 'default-notification';
+  }
+
+  /**
+   * Mark notification as read
+   */
+  async markAsRead(notificationId: string): Promise<ApiResponse<boolean>> {
+    try {
+      const notification = this.notifications.get(notificationId);
+      if (!notification) {
+        throw new Error('Notification not found');
+      }
+
+      notification.isRead = true;
+      this.notifications.set(notificationId, notification);
+
+      return {
+        success: true,
+        data: true,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to mark notification as read', error);
+    }
+  }
+
+  /**
+   * Mark all notifications as read for a user
+   */
+  async markAllAsRead(userId: string): Promise<ApiResponse<number>> {
+    try {
+      let count = 0;
+      for (const [id, notification] of this.notifications.entries()) {
+        if (notification.userId === userId && !notification.isRead) {
+          notification.isRead = true;
+          this.notifications.set(id, notification);
+          count++;
+        }
+      }
+
+      return {
+        success: true,
+        data: count,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to mark all notifications as read', error);
+    }
+  }
+
+  /**
+   * Delete notification
+   */
+  async deleteNotification(notificationId: string): Promise<ApiResponse<boolean>> {
+    try {
+      const deleted = this.notifications.delete(notificationId);
+      if (!deleted) {
+        throw new Error('Notification not found');
+      }
+
+      return {
+        success: true,
+        data: true,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to delete notification', error);
+    }
+  }
+
+  /**
+   * Get notifications for a user
+   */
+  async getUserNotifications(
+    userId: string,
+    limit: number = 50,
+    offset: number = 0,
+    unreadOnly: boolean = false
+  ): Promise<ApiResponse<Notification[]>> {
+    try {
+      let notifications = Array.from(this.notifications.values())
+        .filter(notification => notification.userId === userId);
+
+      if (unreadOnly) {
+        notifications = notifications.filter(notification => !notification.isRead);
+      }
+
+      // Sort by creation date (newest first)
+      notifications.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+
+      // Apply pagination
+      const paginatedNotifications = notifications.slice(offset, offset + limit);
+
+      return {
+        success: true,
+        data: paginatedNotifications,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to get user notifications', error);
+    }
+  }
+
+  /**
+   * Get unread notification count for a user
+   */
+  async getUnreadCount(userId: string): Promise<ApiResponse<number>> {
+    try {
+      const count = Array.from(this.notifications.values())
+        .filter(notification => notification.userId === userId && !notification.isRead)
+        .length;
+
+      return {
+        success: true,
+        data: count,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to get unread count', error);
+    }
+  }
+
+  /**
+   * Subscribe to notification updates
+   */
+  subscribe(userId: string, callback: (notification: Notification) => void): string {
+    const subscriptionId = this.generateId();
+    this.subscribers.set(subscriptionId, callback);
+    return subscriptionId;
+  }
+
+  /**
+   * Unsubscribe from notification updates
+   */
+  unsubscribe(subscriptionId: string): boolean {
+    return this.subscribers.delete(subscriptionId);
+  }
+
+  /**
+   * Notify all subscribers
+   */
+  private notifySubscribers(notification: Notification): void {
+    this.subscribers.forEach(callback => {
+      try {
+        callback(notification);
+      } catch (error) {
+        console.error('Error in notification subscriber:', error);
+      }
+    });
+  }
+
+  /**
+   * Schedule a notification for later
+   */
+  async scheduleNotification(
+    userId: string,
+    type: Notification['type'],
+    title: string,
+    message: string,
+    scheduledFor: string,
+    priority: Notification['priority'] = 'medium',
+    data?: any
+  ): Promise<ApiResponse<Notification>> {
+    try {
+      const notification: Notification = {
+        id: this.generateId(),
+        userId,
+        type,
+        title,
+        message,
+        data,
+        isRead: false,
+        createdAt: new Date().toISOString(),
+        expiresAt: new Date(new Date(scheduledFor).getTime() + 24 * 60 * 60 * 1000).toISOString(), // 24 hours after scheduled time
+        priority,
+      };
+
+      this.notifications.set(notification.id, notification);
+
+      // Schedule the actual sending
+      const delay = new Date(scheduledFor).getTime() - Date.now();
+      if (delay > 0) {
+        setTimeout(async () => {
+          await this.sendToChannels(notification);
+          this.notifySubscribers(notification);
+        }, delay);
+      } else {
+        // Send immediately if scheduled time has passed
+        await this.sendToChannels(notification);
+        this.notifySubscribers(notification);
+      }
+
+      return {
+        success: true,
+        data: notification,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to schedule notification', error);
+    }
+  }
+
+  /**
+   * Create calendar reminder notification
+   */
+  async createCalendarReminder(
+    userId: string,
+    event: CalendarEvent,
+    reminder: CalendarReminder
+  ): Promise<ApiResponse<Notification>> {
+    try {
+      const reminderTime = new Date(event.startTime);
+      reminderTime.setMinutes(reminderTime.getMinutes() - reminder.timeBeforeEvent);
+
+      const title = `Reminder: ${event.title}`;
+      const message = `Your event starts in ${reminder.timeBeforeEvent} minutes`;
+
+      return await this.scheduleNotification(
+        userId,
+        'system',
+        title,
+        message,
+        reminderTime.toISOString(),
+        'medium',
+        { eventId: event.id, eventType: event.type }
+      );
+    } catch (error) {
+      return this.handleError('Failed to create calendar reminder', error);
+    }
+  }
+
+  /**
+   * Bulk create notifications
+   */
+  async bulkCreateNotifications(
+    notifications: Array<{
+      userId: string;
+      type: Notification['type'];
+      title: string;
+      message: string;
+      priority?: Notification['priority'];
+      data?: any;
+      actionUrl?: string;
+    }>
+  ): Promise<ApiResponse<Notification[]>> {
+    try {
+      const createdNotifications: Notification[] = [];
+
+      for (const notificationData of notifications) {
+        const result = await this.createNotification(
+          notificationData.userId,
+          notificationData.type,
+          notificationData.title,
+          notificationData.message,
+          notificationData.priority,
+          notificationData.data,
+          notificationData.actionUrl
+        );
+
+        if (result.success && result.data) {
+          createdNotifications.push(result.data);
+        }
+      }
+
+      return {
+        success: true,
+        data: createdNotifications,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to bulk create notifications', error);
+    }
+  }
+
+  /**
+   * Clean up expired notifications
+   */
+  async cleanupExpiredNotifications(): Promise<ApiResponse<number>> {
+    try {
+      const now = new Date().toISOString();
+      let deletedCount = 0;
+
+      for (const [id, notification] of this.notifications.entries()) {
+        if (notification.expiresAt && notification.expiresAt < now) {
+          this.notifications.delete(id);
+          deletedCount++;
+        }
+      }
+
+      return {
+        success: true,
+        data: deletedCount,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to cleanup expired notifications', error);
+    }
+  }
+
+  /**
+   * Convert VAPID key to Uint8Array
+   */
+  private urlBase64ToUint8Array(base64String: string): Uint8Array {
+    const padding = '='.repeat((4 - base64String.length % 4) % 4);
+    const base64 = (base64String + padding)
+      .replace(/-/g, '+')
+      .replace(/_/g, '/');
+
+    const rawData = window.atob(base64);
+    const outputArray = new Uint8Array(rawData.length);
+
+    for (let i = 0; i < rawData.length; ++i) {
+      outputArray[i] = rawData.charCodeAt(i);
+    }
+    return outputArray;
+  }
+
+  /**
+   * Generate unique ID
+   */
+  private generateId(): string {
+    return Math.random().toString(36).substr(2, 9);
+  }
+
+  /**
+   * Handle errors
+   */
+  private handleError(message: string, error: any): ApiResponse<any> {
+    const appError: AppError = {
+      code: 'NOTIFICATION_ERROR',
+      message,
+      details: error.message,
+      timestamp: new Date().toISOString(),
+    };
+
+    return {
+      success: false,
+      error: message,
+      timestamp: new Date().toISOString(),
+      requestId: this.generateId(),
+    };
+  }
+}
+
+export default NotificationService.getInstance(); 

--- a/src/services/PWAService.ts
+++ b/src/services/PWAService.ts
@@ -1,0 +1,616 @@
+import { 
+  PWAConfig, 
+  PWAIcon, 
+  PWAScreenshot, 
+  ApiResponse, 
+  AppError 
+} from '../types';
+
+/**
+ * Service for managing Progressive Web App features
+ * Handles installation, offline functionality, push notifications, and app updates
+ */
+export class PWAService {
+  private static instance: PWAService;
+  private config: PWAConfig;
+  private deferredPrompt: any = null;
+  private isInstalled: boolean = false;
+  private isOnline: boolean = navigator.onLine;
+  private updateAvailable: boolean = false;
+  private subscribers: Map<string, (event: string, data?: any) => void> = new Map();
+
+  private constructor() {
+    this.initializeConfig();
+    this.setupEventListeners();
+    this.checkInstallationStatus();
+  }
+
+  static getInstance(): PWAService {
+    if (!PWAService.instance) {
+      PWAService.instance = new PWAService();
+    }
+    return PWAService.instance;
+  }
+
+  /**
+   * Initialize PWA configuration
+   */
+  private initializeConfig(): void {
+    this.config = {
+      name: 'VGC Hub',
+      shortName: 'VGC Hub',
+      description: 'Pokémon VGC Tournament Tracker and Community Platform',
+      themeColor: '#3B82F6',
+      backgroundColor: '#FFFFFF',
+      display: 'standalone',
+      orientation: 'portrait',
+      scope: '/',
+      startUrl: '/',
+      icons: [
+        {
+          src: '/icon-192.png',
+          sizes: '192x192',
+          type: 'image/png',
+          purpose: 'maskable',
+        },
+        {
+          src: '/icon-512.png',
+          sizes: '512x512',
+          type: 'image/png',
+          purpose: 'maskable',
+        },
+        {
+          src: '/icon-192.png',
+          sizes: '192x192',
+          type: 'image/png',
+          purpose: 'any',
+        },
+        {
+          src: '/icon-512.png',
+          sizes: '512x512',
+          type: 'image/png',
+          purpose: 'any',
+        },
+      ],
+      screenshots: [
+        {
+          src: '/screenshot-wide.png',
+          sizes: '1280x720',
+          type: 'image/png',
+          formFactor: 'wide',
+          label: 'VGC Hub Dashboard',
+        },
+        {
+          src: '/screenshot-narrow.png',
+          sizes: '750x1334',
+          type: 'image/png',
+          formFactor: 'narrow',
+          label: 'VGC Hub Mobile View',
+        },
+      ],
+      categories: ['games', 'sports', 'social'],
+      lang: 'en',
+    };
+  }
+
+  /**
+   * Setup event listeners for PWA features
+   */
+  private setupEventListeners(): void {
+    // Before install prompt
+    window.addEventListener('beforeinstallprompt', (e) => {
+      e.preventDefault();
+      this.deferredPrompt = e;
+      this.notifySubscribers('install-available');
+    });
+
+    // App installed
+    window.addEventListener('appinstalled', () => {
+      this.isInstalled = true;
+      this.deferredPrompt = null;
+      this.notifySubscribers('installed');
+    });
+
+    // Online/offline status
+    window.addEventListener('online', () => {
+      this.isOnline = true;
+      this.notifySubscribers('online');
+    });
+
+    window.addEventListener('offline', () => {
+      this.isOnline = false;
+      this.notifySubscribers('offline');
+    });
+
+    // Service worker updates
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.addEventListener('controllerchange', () => {
+        this.notifySubscribers('controller-change');
+      });
+
+      navigator.serviceWorker.addEventListener('message', (event) => {
+        this.handleServiceWorkerMessage(event.data);
+      });
+    }
+  }
+
+  /**
+   * Check if app is installed
+   */
+  private async checkInstallationStatus(): Promise<void> {
+    if ('getInstalledRelatedApps' in navigator) {
+      try {
+        const relatedApps = await (navigator as any).getInstalledRelatedApps();
+        this.isInstalled = relatedApps.length > 0;
+      } catch (error) {
+        console.error('Failed to check installation status:', error);
+      }
+    }
+
+    // Check if running in standalone mode (installed)
+    if (window.matchMedia('(display-mode: standalone)').matches) {
+      this.isInstalled = true;
+    }
+  }
+
+  /**
+   * Get PWA configuration
+   */
+  getConfig(): PWAConfig {
+    return { ...this.config };
+  }
+
+  /**
+   * Check if PWA can be installed
+   */
+  canInstall(): boolean {
+    return this.deferredPrompt !== null && !this.isInstalled;
+  }
+
+  /**
+   * Show install prompt
+   */
+  async showInstallPrompt(): Promise<ApiResponse<boolean>> {
+    try {
+      if (!this.canInstall()) {
+        throw new Error('Install prompt not available');
+      }
+
+      this.deferredPrompt.prompt();
+      const { outcome } = await this.deferredPrompt.userChoice;
+      
+      if (outcome === 'accepted') {
+        this.deferredPrompt = null;
+        return {
+          success: true,
+          data: true,
+          timestamp: new Date().toISOString(),
+          requestId: this.generateId(),
+        };
+      } else {
+        throw new Error('Installation was declined');
+      }
+    } catch (error) {
+      return this.handleError('Failed to show install prompt', error);
+    }
+  }
+
+  /**
+   * Check if app is installed
+   */
+  isAppInstalled(): boolean {
+    return this.isInstalled;
+  }
+
+  /**
+   * Check online status
+   */
+  isAppOnline(): boolean {
+    return this.isOnline;
+  }
+
+  /**
+   * Check if update is available
+   */
+  isUpdateAvailable(): boolean {
+    return this.updateAvailable;
+  }
+
+  /**
+   * Register service worker
+   */
+  async registerServiceWorker(): Promise<ApiResponse<ServiceWorkerRegistration>> {
+    try {
+      if (!('serviceWorker' in navigator)) {
+        throw new Error('Service Worker not supported');
+      }
+
+      const registration = await navigator.serviceWorker.register('/sw.js', {
+        scope: this.config.scope,
+      });
+
+      // Check for updates
+      registration.addEventListener('updatefound', () => {
+        const newWorker = registration.installing;
+        if (newWorker) {
+          newWorker.addEventListener('statechange', () => {
+            if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+              this.updateAvailable = true;
+              this.notifySubscribers('update-available');
+            }
+          });
+        }
+      });
+
+      return {
+        success: true,
+        data: registration,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to register service worker', error);
+    }
+  }
+
+  /**
+   * Update service worker
+   */
+  async updateServiceWorker(): Promise<ApiResponse<boolean>> {
+    try {
+      if (!('serviceWorker' in navigator)) {
+        throw new Error('Service Worker not supported');
+      }
+
+      const registration = await navigator.serviceWorker.getRegistration();
+      if (!registration) {
+        throw new Error('No service worker registration found');
+      }
+
+      await registration.update();
+      this.updateAvailable = false;
+
+      return {
+        success: true,
+        data: true,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to update service worker', error);
+    }
+  }
+
+  /**
+   * Request push notification permission
+   */
+  async requestPushPermission(): Promise<ApiResponse<boolean>> {
+    try {
+      if (!('Notification' in window)) {
+        throw new Error('Push notifications not supported');
+      }
+
+      const permission = await Notification.requestPermission();
+      const granted = permission === 'granted';
+
+      if (granted) {
+        await this.subscribeToPushNotifications();
+      }
+
+      return {
+        success: true,
+        data: granted,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to request push permission', error);
+    }
+  }
+
+  /**
+   * Subscribe to push notifications
+   */
+  private async subscribeToPushNotifications(): Promise<void> {
+    try {
+      const registration = await navigator.serviceWorker.ready;
+      const subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: this.urlBase64ToUint8Array(process.env.VAPID_PUBLIC_KEY || ''),
+      });
+
+      // Send subscription to server
+      await this.sendSubscriptionToServer(subscription);
+    } catch (error) {
+      console.error('Failed to subscribe to push notifications:', error);
+    }
+  }
+
+  /**
+   * Send push subscription to server
+   */
+  private async sendSubscriptionToServer(subscription: PushSubscription): Promise<void> {
+    try {
+      // This would send the subscription to your backend
+      const response = await fetch('/api/push/subscribe', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(subscription),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to send subscription to server');
+      }
+    } catch (error) {
+      console.error('Failed to send subscription to server:', error);
+    }
+  }
+
+  /**
+   * Handle service worker messages
+   */
+  private handleServiceWorkerMessage(data: any): void {
+    switch (data.type) {
+      case 'PUSH_RECEIVED':
+        this.notifySubscribers('push-received', data.payload);
+        break;
+      case 'BACKGROUND_SYNC':
+        this.notifySubscribers('background-sync', data.payload);
+        break;
+      case 'CACHE_UPDATED':
+        this.notifySubscribers('cache-updated', data.payload);
+        break;
+      default:
+        console.log('Unknown service worker message:', data);
+    }
+  }
+
+  /**
+   * Cache data for offline use
+   */
+  async cacheData(key: string, data: any): Promise<ApiResponse<boolean>> {
+    try {
+      if ('caches' in window) {
+        const cache = await caches.open('vgc-hub-data');
+        const response = new Response(JSON.stringify(data), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+        await cache.put(key, response);
+
+        return {
+          success: true,
+          data: true,
+          timestamp: new Date().toISOString(),
+          requestId: this.generateId(),
+        };
+      } else {
+        // Fallback to localStorage
+        localStorage.setItem(`pwa-cache-${key}`, JSON.stringify(data));
+        return {
+          success: true,
+          data: true,
+          timestamp: new Date().toISOString(),
+          requestId: this.generateId(),
+        };
+      }
+    } catch (error) {
+      return this.handleError('Failed to cache data', error);
+    }
+  }
+
+  /**
+   * Get cached data
+   */
+  async getCachedData(key: string): Promise<ApiResponse<any>> {
+    try {
+      if ('caches' in window) {
+        const cache = await caches.open('vgc-hub-data');
+        const response = await cache.match(key);
+        
+        if (response) {
+          const data = await response.json();
+          return {
+            success: true,
+            data,
+            timestamp: new Date().toISOString(),
+            requestId: this.generateId(),
+          };
+        }
+      } else {
+        // Fallback to localStorage
+        const data = localStorage.getItem(`pwa-cache-${key}`);
+        if (data) {
+          return {
+            success: true,
+            data: JSON.parse(data),
+            timestamp: new Date().toISOString(),
+            requestId: this.generateId(),
+          };
+        }
+      }
+
+      throw new Error('Cached data not found');
+    } catch (error) {
+      return this.handleError('Failed to get cached data', error);
+    }
+  }
+
+  /**
+   * Clear cached data
+   */
+  async clearCachedData(key?: string): Promise<ApiResponse<boolean>> {
+    try {
+      if ('caches' in window) {
+        if (key) {
+          const cache = await caches.open('vgc-hub-data');
+          await cache.delete(key);
+        } else {
+          await caches.delete('vgc-hub-data');
+        }
+      } else {
+        // Fallback to localStorage
+        if (key) {
+          localStorage.removeItem(`pwa-cache-${key}`);
+        } else {
+          Object.keys(localStorage)
+            .filter(k => k.startsWith('pwa-cache-'))
+            .forEach(k => localStorage.removeItem(k));
+        }
+      }
+
+      return {
+        success: true,
+        data: true,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to clear cached data', error);
+    }
+  }
+
+  /**
+   * Get app usage statistics
+   */
+  async getAppUsageStats(): Promise<ApiResponse<any>> {
+    try {
+      if ('getInstalledRelatedApps' in navigator) {
+        const relatedApps = await (navigator as any).getInstalledRelatedApps();
+        
+        const stats = {
+          isInstalled: this.isInstalled,
+          isOnline: this.isOnline,
+          updateAvailable: this.updateAvailable,
+          relatedApps: relatedApps.length,
+          displayMode: this.getDisplayMode(),
+          platform: this.getPlatform(),
+          userAgent: navigator.userAgent,
+        };
+
+        return {
+          success: true,
+          data: stats,
+          timestamp: new Date().toISOString(),
+          requestId: this.generateId(),
+        };
+      } else {
+        throw new Error('App usage statistics not supported');
+      }
+    } catch (error) {
+      return this.handleError('Failed to get app usage stats', error);
+    }
+  }
+
+  /**
+   * Get display mode
+   */
+  private getDisplayMode(): string {
+    if (window.matchMedia('(display-mode: standalone)').matches) {
+      return 'standalone';
+    } else if (window.matchMedia('(display-mode: fullscreen)').matches) {
+      return 'fullscreen';
+    } else if (window.matchMedia('(display-mode: minimal-ui)').matches) {
+      return 'minimal-ui';
+    } else {
+      return 'browser';
+    }
+  }
+
+  /**
+   * Get platform
+   */
+  private getPlatform(): string {
+    const userAgent = navigator.userAgent.toLowerCase();
+    
+    if (userAgent.includes('android')) {
+      return 'android';
+    } else if (userAgent.includes('iphone') || userAgent.includes('ipad')) {
+      return 'ios';
+    } else if (userAgent.includes('windows')) {
+      return 'windows';
+    } else if (userAgent.includes('mac')) {
+      return 'macos';
+    } else if (userAgent.includes('linux')) {
+      return 'linux';
+    } else {
+      return 'unknown';
+    }
+  }
+
+  /**
+   * Subscribe to PWA events
+   */
+  subscribe(callback: (event: string, data?: any) => void): string {
+    const subscriptionId = this.generateId();
+    this.subscribers.set(subscriptionId, callback);
+    return subscriptionId;
+  }
+
+  /**
+   * Unsubscribe from PWA events
+   */
+  unsubscribe(subscriptionId: string): boolean {
+    return this.subscribers.delete(subscriptionId);
+  }
+
+  /**
+   * Notify subscribers of events
+   */
+  private notifySubscribers(event: string, data?: any): void {
+    this.subscribers.forEach(callback => {
+      try {
+        callback(event, data);
+      } catch (error) {
+        console.error('Error in PWA subscriber:', error);
+      }
+    });
+  }
+
+  /**
+   * Convert VAPID key to Uint8Array
+   */
+  private urlBase64ToUint8Array(base64String: string): Uint8Array {
+    const padding = '='.repeat((4 - base64String.length % 4) % 4);
+    const base64 = (base64String + padding)
+      .replace(/-/g, '+')
+      .replace(/_/g, '/');
+
+    const rawData = window.atob(base64);
+    const outputArray = new Uint8Array(rawData.length);
+
+    for (let i = 0; i < rawData.length; ++i) {
+      outputArray[i] = rawData.charCodeAt(i);
+    }
+    return outputArray;
+  }
+
+  /**
+   * Generate unique ID
+   */
+  private generateId(): string {
+    return Math.random().toString(36).substr(2, 9);
+  }
+
+  /**
+   * Handle errors
+   */
+  private handleError(message: string, error: any): ApiResponse<any> {
+    const appError: AppError = {
+      code: 'PWA_ERROR',
+      message,
+      details: error.message,
+      timestamp: new Date().toISOString(),
+    };
+
+    return {
+      success: false,
+      error: message,
+      timestamp: new Date().toISOString(),
+      requestId: this.generateId(),
+    };
+  }
+}
+
+export default PWAService.getInstance(); 

--- a/src/services/TeamAnalyticsService.ts
+++ b/src/services/TeamAnalyticsService.ts
@@ -1,0 +1,843 @@
+import { 
+  Team, 
+  Pokemon, 
+  TeamAnalytics, 
+  TeamUsage, 
+  TeamMatchup, 
+  TeamWeakness, 
+  TeamStrength, 
+  TeamRecommendation,
+  MetaTrend,
+  PokemonUsage,
+  ItemUsage,
+  MoveUsage,
+  ApiResponse,
+  AppError
+} from '../types';
+
+/**
+ * Service for advanced team analytics and meta analysis
+ * Provides matchup calculations, usage statistics, and strategic insights
+ */
+export class TeamAnalyticsService {
+  private static instance: TeamAnalyticsService;
+  private teams: Map<string, Team> = new Map();
+  private metaData: MetaTrend[] = [];
+
+  private constructor() {
+    this.initializeMetaData();
+  }
+
+  static getInstance(): TeamAnalyticsService {
+    if (!TeamAnalyticsService.instance) {
+      TeamAnalyticsService.instance = new TeamAnalyticsService();
+    }
+    return TeamAnalyticsService.instance;
+  }
+
+  /**
+   * Analyze a team and provide comprehensive insights
+   */
+  async analyzeTeam(team: Team): Promise<ApiResponse<TeamAnalytics>> {
+    try {
+      const analytics: TeamAnalytics = {
+        teamId: team.id,
+        usage: await this.calculateTeamUsage(team),
+        matchups: await this.analyzeMatchups(team),
+        weaknesses: await this.identifyWeaknesses(team),
+        strengths: await this.identifyStrengths(team),
+        recommendations: await this.generateRecommendations(team),
+        metaTrends: this.getRelevantMetaTrends(team),
+      };
+
+      return {
+        success: true,
+        data: analytics,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to analyze team', error);
+    }
+  }
+
+  /**
+   * Calculate team usage statistics
+   */
+  private async calculateTeamUsage(team: Team): Promise<TeamUsage> {
+    const totalUsage = team.usageCount || 0;
+    const winRate = team.winRate || 0;
+    const averagePlacement = this.calculateAveragePlacement(team);
+    const tournaments = this.getTournamentCount(team);
+    const recentTrend = this.calculateRecentTrend(team);
+
+    return {
+      totalUsage,
+      winRate,
+      averagePlacement,
+      tournaments,
+      recentTrend,
+    };
+  }
+
+  /**
+   * Analyze team matchups against common meta teams
+   */
+  private async analyzeMatchups(team: Team): Promise<TeamMatchup[]> {
+    const commonTeams = this.getCommonMetaTeams();
+    const matchups: TeamMatchup[] = [];
+
+    for (const metaTeam of commonTeams) {
+      const winRate = this.calculateMatchupWinRate(team, metaTeam);
+      const gamesPlayed = this.getGamesPlayed(team, metaTeam);
+      const difficulty = this.assessMatchupDifficulty(winRate);
+      const strategy = this.generateMatchupStrategy(team, metaTeam, winRate);
+
+      matchups.push({
+        opponentTeam: metaTeam.pokemon,
+        winRate,
+        gamesPlayed,
+        difficulty,
+        strategy,
+      });
+    }
+
+    return matchups.sort((a, b) => b.winRate - a.winRate);
+  }
+
+  /**
+   * Identify team weaknesses
+   */
+  private async identifyWeaknesses(team: Team): Promise<TeamWeakness[]> {
+    const weaknesses: TeamWeakness[] = [];
+
+    // Type weaknesses
+    const typeWeaknesses = this.analyzeTypeWeaknesses(team);
+    weaknesses.push(...typeWeaknesses);
+
+    // Coverage gaps
+    const coverageGaps = this.analyzeCoverageGaps(team);
+    weaknesses.push(...coverageGaps);
+
+    // Speed control issues
+    const speedIssues = this.analyzeSpeedControl(team);
+    weaknesses.push(...speedIssues);
+
+    // Item distribution issues
+    const itemIssues = this.analyzeItemDistribution(team);
+    weaknesses.push(...itemIssues);
+
+    return weaknesses.sort((a, b) => {
+      const severityOrder = { high: 3, medium: 2, low: 1 };
+      return severityOrder[b.severity] - severityOrder[a.severity];
+    });
+  }
+
+  /**
+   * Identify team strengths
+   */
+  private async identifyStrengths(team: Team): Promise<TeamStrength[]> {
+    const strengths: TeamStrength[] = [];
+
+    // Type coverage strengths
+    const typeStrengths = this.analyzeTypeStrengths(team);
+    strengths.push(...typeStrengths);
+
+    // Synergy strengths
+    const synergyStrengths = this.analyzeTeamSynergy(team);
+    strengths.push(...synergyStrengths);
+
+    // Speed control strengths
+    const speedStrengths = this.analyzeSpeedStrengths(team);
+    strengths.push(...speedStrengths);
+
+    return strengths;
+  }
+
+  /**
+   * Generate team recommendations
+   */
+  private async generateRecommendations(team: Team): Promise<TeamRecommendation[]> {
+    const recommendations: TeamRecommendation[] = [];
+
+    // Pokemon recommendations
+    const pokemonRecs = this.generatePokemonRecommendations(team);
+    recommendations.push(...pokemonRecs);
+
+    // Item recommendations
+    const itemRecs = this.generateItemRecommendations(team);
+    recommendations.push(...itemRecs);
+
+    // Move recommendations
+    const moveRecs = this.generateMoveRecommendations(team);
+    recommendations.push(...moveRecs);
+
+    // Strategy recommendations
+    const strategyRecs = this.generateStrategyRecommendations(team);
+    recommendations.push(...strategyRecs);
+
+    return recommendations.sort((a, b) => {
+      const impactOrder = { high: 3, medium: 2, low: 1 };
+      return impactOrder[b.impact] - impactOrder[a.impact];
+    });
+  }
+
+  /**
+   * Get relevant meta trends for the team
+   */
+  private getRelevantMetaTrends(team: Team): MetaTrend[] {
+    return this.metaData.filter(trend => 
+      trend.topPokemon.some(pokemon => 
+        team.pokemon.some(teamPokemon => teamPokemon.name === pokemon.name)
+      )
+    );
+  }
+
+  /**
+   * Analyze type weaknesses in the team
+   */
+  private analyzeTypeWeaknesses(team: Team): TeamWeakness[] {
+    const weaknesses: TeamWeakness[] = [];
+    const typeChart = this.getTypeChart();
+
+    // Check for common attacking types that are super effective
+    const commonAttackingTypes = ['Fighting', 'Flying', 'Ground', 'Rock', 'Steel', 'Fire', 'Water', 'Grass', 'Electric', 'Ice', 'Psychic', 'Dark', 'Fairy'];
+    
+    for (const attackingType of commonAttackingTypes) {
+      let superEffectiveCount = 0;
+      let totalPokemon = team.pokemon.length;
+
+      for (const pokemon of team.pokemon) {
+        const pokemonTypes = this.getPokemonTypes(pokemon.name);
+        for (const pokemonType of pokemonTypes) {
+          if (typeChart[pokemonType]?.[attackingType] > 1) {
+            superEffectiveCount++;
+          }
+        }
+      }
+
+      if (superEffectiveCount >= totalPokemon * 0.5) {
+        const severity = superEffectiveCount >= totalPokemon * 0.8 ? 'high' : 'medium';
+        weaknesses.push({
+          type: attackingType,
+          severity,
+          description: `${superEffectiveCount}/${totalPokemon} Pokémon are weak to ${attackingType}`,
+          counterStrategies: this.getCounterStrategies(attackingType),
+        });
+      }
+    }
+
+    return weaknesses;
+  }
+
+  /**
+   * Analyze coverage gaps in the team
+   */
+  private analyzeCoverageGaps(team: Team): TeamWeakness[] {
+    const weaknesses: TeamWeakness[] = [];
+    const typeChart = this.getTypeChart();
+    const commonTypes = ['Normal', 'Fire', 'Water', 'Electric', 'Grass', 'Ice', 'Fighting', 'Poison', 'Ground', 'Flying', 'Psychic', 'Bug', 'Rock', 'Ghost', 'Dragon', 'Dark', 'Steel', 'Fairy'];
+
+    for (const defendingType of commonTypes) {
+      let effectiveMoves = 0;
+      let totalMoves = 0;
+
+      for (const pokemon of team.pokemon) {
+        if (pokemon.moves) {
+          for (const move of pokemon.moves) {
+            const moveType = this.getMoveType(move);
+            if (typeChart[moveType]?.[defendingType] >= 1) {
+              effectiveMoves++;
+            }
+            totalMoves++;
+          }
+        }
+      }
+
+      if (effectiveMoves === 0 && totalMoves > 0) {
+        weaknesses.push({
+          type: defendingType,
+          severity: 'medium',
+          description: `No moves effective against ${defendingType} types`,
+          counterStrategies: [`Add a ${this.getSuperEffectiveType(defendingType)} type move`],
+        });
+      }
+    }
+
+    return weaknesses;
+  }
+
+  /**
+   * Analyze speed control issues
+   */
+  private analyzeSpeedControl(team: Team): TeamWeakness[] {
+    const weaknesses: TeamWeakness[] = [];
+    const speedMoves = ['Tailwind', 'Max Airstream', 'Icy Wind', 'Electroweb', 'Rock Tomb'];
+    const priorityMoves = ['Extreme Speed', 'Sucker Punch', 'Aqua Jet', 'Bullet Punch', 'Mach Punch'];
+    
+    let hasSpeedControl = false;
+    let hasPriority = false;
+
+    for (const pokemon of team.pokemon) {
+      if (pokemon.moves) {
+        for (const move of pokemon.moves) {
+          if (speedMoves.includes(move)) hasSpeedControl = true;
+          if (priorityMoves.includes(move)) hasPriority = true;
+        }
+      }
+    }
+
+    if (!hasSpeedControl) {
+      weaknesses.push({
+        type: 'Speed Control',
+        severity: 'medium',
+        description: 'Team lacks speed control moves',
+        counterStrategies: ['Add Tailwind, Max Airstream, or Icy Wind'],
+      });
+    }
+
+    if (!hasPriority) {
+      weaknesses.push({
+        type: 'Priority',
+        severity: 'low',
+        description: 'Team lacks priority moves',
+        counterStrategies: ['Add Extreme Speed, Sucker Punch, or other priority moves'],
+      });
+    }
+
+    return weaknesses;
+  }
+
+  /**
+   * Analyze item distribution
+   */
+  private analyzeItemDistribution(team: Team): TeamWeakness[] {
+    const weaknesses: TeamWeakness[] = [];
+    const items = team.pokemon.map(p => p.item).filter(Boolean);
+    const uniqueItems = new Set(items);
+
+    if (uniqueItems.size < items.length) {
+      weaknesses.push({
+        type: 'Item Distribution',
+        severity: 'high',
+        description: 'Multiple Pokémon are holding the same item',
+        counterStrategies: ['Ensure each Pokémon has a unique item'],
+      });
+    }
+
+    return weaknesses;
+  }
+
+  /**
+   * Analyze type strengths
+   */
+  private analyzeTypeStrengths(team: Team): TeamStrength[] {
+    const strengths: TeamStrength[] = [];
+    const typeChart = this.getTypeChart();
+
+    // Check for good defensive coverage
+    const defensiveTypes = new Set<string>();
+    for (const pokemon of team.pokemon) {
+      const pokemonTypes = this.getPokemonTypes(pokemon.name);
+      defensiveTypes.add(...pokemonTypes);
+    }
+
+    if (defensiveTypes.size >= 6) {
+      strengths.push({
+        type: 'Type Diversity',
+        description: 'Team has good type diversity',
+        advantage: 'Reduces overall team weaknesses',
+      });
+    }
+
+    return strengths;
+  }
+
+  /**
+   * Analyze team synergy
+   */
+  private analyzeTeamSynergy(team: Team): TeamStrength[] {
+    const strengths: TeamStrength[] = [];
+
+    // Check for weather synergy
+    const weatherMoves = ['Rain Dance', 'Sunny Day', 'Sandstorm', 'Hail'];
+    const weatherAbilities = ['Drizzle', 'Drought', 'Sand Stream', 'Snow Warning'];
+    
+    let hasWeather = false;
+    for (const pokemon of team.pokemon) {
+      if (pokemon.moves && pokemon.moves.some(move => weatherMoves.includes(move))) {
+        hasWeather = true;
+      }
+      if (pokemon.ability && weatherAbilities.includes(pokemon.ability)) {
+        hasWeather = true;
+      }
+    }
+
+    if (hasWeather) {
+      strengths.push({
+        type: 'Weather Synergy',
+        description: 'Team has weather control',
+        advantage: 'Can control the battlefield conditions',
+      });
+    }
+
+    return strengths;
+  }
+
+  /**
+   * Analyze speed strengths
+   */
+  private analyzeSpeedStrengths(team: Team): TeamStrength[] {
+    const strengths: TeamStrength[] = [];
+
+    // Check for speed control
+    const speedMoves = ['Tailwind', 'Max Airstream', 'Icy Wind'];
+    let hasSpeedControl = false;
+
+    for (const pokemon of team.pokemon) {
+      if (pokemon.moves && pokemon.moves.some(move => speedMoves.includes(move))) {
+        hasSpeedControl = true;
+      }
+    }
+
+    if (hasSpeedControl) {
+      strengths.push({
+        type: 'Speed Control',
+        description: 'Team has speed control options',
+        advantage: 'Can manipulate turn order',
+      });
+    }
+
+    return strengths;
+  }
+
+  /**
+   * Generate Pokemon recommendations
+   */
+  private generatePokemonRecommendations(team: Team): TeamRecommendation[] {
+    const recommendations: TeamRecommendation[] = [];
+
+    // Check for missing roles
+    const roles = this.identifyMissingRoles(team);
+    for (const role of roles) {
+      recommendations.push({
+        type: 'pokemon',
+        suggestion: `Add a ${role} Pokémon`,
+        reasoning: `Team lacks ${role} coverage`,
+        impact: 'medium',
+      });
+    }
+
+    return recommendations;
+  }
+
+  /**
+   * Generate item recommendations
+   */
+  private generateItemRecommendations(team: Team): TeamRecommendation[] {
+    const recommendations: TeamRecommendation[] = [];
+
+    // Check for common item issues
+    const items = team.pokemon.map(p => p.item).filter(Boolean);
+    const uniqueItems = new Set(items);
+
+    if (uniqueItems.size < items.length) {
+      recommendations.push({
+        type: 'item',
+        suggestion: 'Ensure each Pokémon has a unique item',
+        reasoning: 'Multiple Pokémon are holding the same item',
+        impact: 'high',
+      });
+    }
+
+    return recommendations;
+  }
+
+  /**
+   * Generate move recommendations
+   */
+  private generateMoveRecommendations(team: Team): TeamRecommendation[] {
+    const recommendations: TeamRecommendation[] = [];
+
+    // Check for coverage issues
+    const coverageGaps = this.analyzeCoverageGaps(team);
+    for (const gap of coverageGaps) {
+      recommendations.push({
+        type: 'move',
+        suggestion: `Add moves effective against ${gap.type} types`,
+        reasoning: gap.description,
+        impact: 'medium',
+      });
+    }
+
+    return recommendations;
+  }
+
+  /**
+   * Generate strategy recommendations
+   */
+  private generateStrategyRecommendations(team: Team): TeamRecommendation[] {
+    const recommendations: TeamRecommendation[] = [];
+
+    // Check for speed control
+    const speedIssues = this.analyzeSpeedControl(team);
+    for (const issue of speedIssues) {
+      recommendations.push({
+        type: 'strategy',
+        suggestion: issue.counterStrategies[0],
+        reasoning: issue.description,
+        impact: issue.severity === 'high' ? 'high' : 'medium',
+      });
+    }
+
+    return recommendations;
+  }
+
+  /**
+   * Calculate matchup win rate
+   */
+  private calculateMatchupWinRate(team: Team, opponentTeam: Team): number {
+    // Simplified calculation - in reality, this would use historical data
+    const teamStrength = this.calculateTeamStrength(team);
+    const opponentStrength = this.calculateTeamStrength(opponentTeam);
+    
+    const difference = teamStrength - opponentStrength;
+    return Math.max(0.1, Math.min(0.9, 0.5 + difference * 0.1));
+  }
+
+  /**
+   * Calculate team strength score
+   */
+  private calculateTeamStrength(team: Team): number {
+    let strength = 0;
+    
+    for (const pokemon of team.pokemon) {
+      strength += this.getPokemonBaseStats(pokemon.name);
+      if (pokemon.item) strength += 10;
+      if (pokemon.ability) strength += 5;
+    }
+    
+    return strength / team.pokemon.length;
+  }
+
+  /**
+   * Assess matchup difficulty
+   */
+  private assessMatchupDifficulty(winRate: number): 'easy' | 'medium' | 'hard' {
+    if (winRate >= 0.6) return 'easy';
+    if (winRate >= 0.4) return 'medium';
+    return 'hard';
+  }
+
+  /**
+   * Generate matchup strategy
+   */
+  private generateMatchupStrategy(team: Team, opponentTeam: Team, winRate: number): string {
+    if (winRate >= 0.6) {
+      return 'Favorable matchup - play aggressively and maintain momentum';
+    } else if (winRate >= 0.4) {
+      return 'Even matchup - focus on positioning and key plays';
+    } else {
+      return 'Difficult matchup - play defensively and look for opportunities';
+    }
+  }
+
+  /**
+   * Get counter strategies for a type
+   */
+  private getCounterStrategies(type: string): string[] {
+    const strategies: { [key: string]: string[] } = {
+      'Fighting': ['Add Flying or Psychic types', 'Use Protect strategically'],
+      'Flying': ['Add Electric or Rock types', 'Use priority moves'],
+      'Ground': ['Add Flying types', 'Use Levitate ability'],
+      'Rock': ['Add Fighting or Ground types', 'Use priority moves'],
+      'Steel': ['Add Fire or Fighting types', 'Use special attacks'],
+      'Fire': ['Add Water or Ground types', 'Use weather control'],
+      'Water': ['Add Electric or Grass types', 'Use terrain control'],
+      'Grass': ['Add Fire or Flying types', 'Use weather control'],
+      'Electric': ['Add Ground types', 'Use Lightning Rod ability'],
+      'Ice': ['Add Fire or Fighting types', 'Use weather control'],
+      'Psychic': ['Add Dark or Bug types', 'Use priority moves'],
+      'Dark': ['Add Fighting or Fairy types', 'Use priority moves'],
+      'Fairy': ['Add Steel or Poison types', 'Use weather control'],
+    };
+
+    return strategies[type] || ['Add coverage moves', 'Use strategic positioning'];
+  }
+
+  /**
+   * Get super effective type against a type
+   */
+  private getSuperEffectiveType(type: string): string {
+    const superEffective: { [key: string]: string } = {
+      'Normal': 'Fighting',
+      'Fire': 'Water',
+      'Water': 'Electric',
+      'Electric': 'Ground',
+      'Grass': 'Fire',
+      'Ice': 'Fire',
+      'Fighting': 'Flying',
+      'Poison': 'Ground',
+      'Ground': 'Water',
+      'Flying': 'Electric',
+      'Psychic': 'Dark',
+      'Bug': 'Fire',
+      'Rock': 'Water',
+      'Ghost': 'Dark',
+      'Dragon': 'Ice',
+      'Dark': 'Fighting',
+      'Steel': 'Fire',
+      'Fairy': 'Steel',
+    };
+
+    return superEffective[type] || 'Normal';
+  }
+
+  /**
+   * Identify missing roles in the team
+   */
+  private identifyMissingRoles(team: Team): string[] {
+    const roles = new Set<string>();
+    
+    for (const pokemon of team.pokemon) {
+      const pokemonRoles = this.getPokemonRoles(pokemon.name);
+      pokemonRoles.forEach(role => roles.add(role));
+    }
+
+    const allRoles = ['Physical Attacker', 'Special Attacker', 'Support', 'Tank', 'Speed Control'];
+    return allRoles.filter(role => !roles.has(role));
+  }
+
+  /**
+   * Get Pokemon roles (simplified)
+   */
+  private getPokemonRoles(pokemonName: string): string[] {
+    // This would be a comprehensive database in a real implementation
+    const roleDatabase: { [key: string]: string[] } = {
+      'Charizard': ['Special Attacker'],
+      'Blastoise': ['Special Attacker', 'Tank'],
+      'Venusaur': ['Special Attacker', 'Support'],
+      'Pikachu': ['Special Attacker'],
+      'Snorlax': ['Physical Attacker', 'Tank'],
+      'Gyarados': ['Physical Attacker'],
+      'Dragonite': ['Physical Attacker'],
+      'Mewtwo': ['Special Attacker'],
+      'Mew': ['Support'],
+      'Tyranitar': ['Physical Attacker', 'Tank'],
+    };
+
+    return roleDatabase[pokemonName] || ['Physical Attacker'];
+  }
+
+  /**
+   * Get Pokemon types (simplified)
+   */
+  private getPokemonTypes(pokemonName: string): string[] {
+    const typeDatabase: { [key: string]: string[] } = {
+      'Charizard': ['Fire', 'Flying'],
+      'Blastoise': ['Water'],
+      'Venusaur': ['Grass', 'Poison'],
+      'Pikachu': ['Electric'],
+      'Snorlax': ['Normal'],
+      'Gyarados': ['Water', 'Flying'],
+      'Dragonite': ['Dragon', 'Flying'],
+      'Mewtwo': ['Psychic'],
+      'Mew': ['Psychic'],
+      'Tyranitar': ['Rock', 'Dark'],
+    };
+
+    return typeDatabase[pokemonName] || ['Normal'];
+  }
+
+  /**
+   * Get move type (simplified)
+   */
+  private getMoveType(moveName: string): string {
+    const moveDatabase: { [key: string]: string } = {
+      'Flamethrower': 'Fire',
+      'Hydro Pump': 'Water',
+      'Thunderbolt': 'Electric',
+      'Ice Beam': 'Ice',
+      'Earthquake': 'Ground',
+      'Psychic': 'Psychic',
+      'Shadow Ball': 'Ghost',
+      'Dragon Claw': 'Dragon',
+      'Crunch': 'Dark',
+      'Iron Head': 'Steel',
+      'Play Rough': 'Fairy',
+    };
+
+    return moveDatabase[moveName] || 'Normal';
+  }
+
+  /**
+   * Get Pokemon base stats (simplified)
+   */
+  private getPokemonBaseStats(pokemonName: string): number {
+    const statsDatabase: { [key: string]: number } = {
+      'Charizard': 534,
+      'Blastoise': 530,
+      'Venusaur': 525,
+      'Pikachu': 320,
+      'Snorlax': 540,
+      'Gyarados': 540,
+      'Dragonite': 600,
+      'Mewtwo': 680,
+      'Mew': 600,
+      'Tyranitar': 600,
+    };
+
+    return statsDatabase[pokemonName] || 400;
+  }
+
+  /**
+   * Get common meta teams
+   */
+  private getCommonMetaTeams(): Team[] {
+    // This would be populated with real meta data
+    return [
+      {
+        id: 'meta-team-1',
+        name: 'Sun Team',
+        pokemon: [
+          { name: 'Charizard', item: 'Charcoal', ability: 'Solar Power', moves: ['Flamethrower', 'Air Slash', 'Solar Beam', 'Focus Blast'] },
+          { name: 'Venusaur', item: 'Life Orb', ability: 'Chlorophyll', moves: ['Giga Drain', 'Sludge Bomb', 'Sleep Powder', 'Growth'] },
+        ],
+        format: 'VGC',
+        isPublic: true,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        createdBy: 'meta',
+        tags: ['sun', 'offensive'],
+        usageCount: 1000,
+        winRate: 0.65,
+      },
+      {
+        id: 'meta-team-2',
+        name: 'Rain Team',
+        pokemon: [
+          { name: 'Blastoise', item: 'Mystic Water', ability: 'Torrent', moves: ['Hydro Pump', 'Ice Beam', 'Dark Pulse', 'Aura Sphere'] },
+          { name: 'Gyarados', item: 'Wacan Berry', ability: 'Intimidate', moves: ['Waterfall', 'Bounce', 'Protect', 'Dragon Dance'] },
+        ],
+        format: 'VGC',
+        isPublic: true,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        createdBy: 'meta',
+        tags: ['rain', 'balanced'],
+        usageCount: 800,
+        winRate: 0.62,
+      },
+    ];
+  }
+
+  /**
+   * Get type chart (simplified)
+   */
+  private getTypeChart(): { [key: string]: { [key: string]: number } } {
+    return {
+      'Normal': { 'Rock': 0.5, 'Ghost': 0, 'Steel': 0.5 },
+      'Fire': { 'Fire': 0.5, 'Water': 0.5, 'Grass': 2, 'Ice': 2, 'Bug': 2, 'Rock': 0.5, 'Dragon': 0.5, 'Steel': 2 },
+      'Water': { 'Fire': 2, 'Water': 0.5, 'Grass': 0.5, 'Ground': 2, 'Rock': 2, 'Dragon': 0.5 },
+      'Electric': { 'Water': 2, 'Electric': 0.5, 'Grass': 0.5, 'Ground': 0, 'Flying': 2, 'Dragon': 0.5 },
+      'Grass': { 'Fire': 0.5, 'Water': 2, 'Grass': 0.5, 'Poison': 0.5, 'Ground': 2, 'Flying': 0.5, 'Bug': 0.5, 'Rock': 2, 'Dragon': 0.5, 'Steel': 0.5 },
+      'Ice': { 'Fire': 0.5, 'Water': 0.5, 'Grass': 2, 'Ice': 0.5, 'Ground': 2, 'Flying': 2, 'Dragon': 2, 'Steel': 0.5 },
+      'Fighting': { 'Normal': 2, 'Ice': 2, 'Poison': 0.5, 'Flying': 0.5, 'Psychic': 0.5, 'Bug': 0.5, 'Rock': 2, 'Ghost': 0, 'Steel': 2, 'Fairy': 0.5 },
+      'Poison': { 'Grass': 2, 'Poison': 0.5, 'Ground': 0.5, 'Rock': 0.5, 'Ghost': 0.5, 'Steel': 0, 'Fairy': 2 },
+      'Ground': { 'Fire': 2, 'Electric': 2, 'Grass': 0.5, 'Poison': 2, 'Flying': 0, 'Bug': 0.5, 'Rock': 2, 'Steel': 2 },
+      'Flying': { 'Electric': 0.5, 'Grass': 2, 'Fighting': 2, 'Bug': 2, 'Rock': 0.5, 'Steel': 0.5 },
+      'Psychic': { 'Fighting': 2, 'Poison': 2, 'Psychic': 0.5, 'Dark': 0, 'Steel': 0.5 },
+      'Bug': { 'Fire': 0.5, 'Grass': 2, 'Fighting': 0.5, 'Poison': 0.5, 'Flying': 0.5, 'Psychic': 2, 'Ghost': 0.5, 'Dark': 2, 'Steel': 0.5, 'Fairy': 0.5 },
+      'Rock': { 'Fire': 2, 'Ice': 2, 'Fighting': 0.5, 'Ground': 0.5, 'Flying': 2, 'Bug': 2, 'Steel': 0.5 },
+      'Ghost': { 'Normal': 0, 'Psychic': 2, 'Ghost': 2, 'Dark': 0.5 },
+      'Dragon': { 'Dragon': 2, 'Steel': 0.5, 'Fairy': 0 },
+      'Dark': { 'Fighting': 0.5, 'Psychic': 2, 'Ghost': 2, 'Dark': 0.5, 'Fairy': 0.5 },
+      'Steel': { 'Fire': 0.5, 'Water': 0.5, 'Electric': 0.5, 'Ice': 2, 'Rock': 2, 'Steel': 0.5, 'Fairy': 2 },
+      'Fairy': { 'Fighting': 2, 'Poison': 0.5, 'Dragon': 2, 'Dark': 2, 'Steel': 0.5 },
+    };
+  }
+
+  /**
+   * Calculate average placement
+   */
+  private calculateAveragePlacement(team: Team): number {
+    // This would use real tournament data
+    return 4.5;
+  }
+
+  /**
+   * Get tournament count
+   */
+  private getTournamentCount(team: Team): number {
+    return team.usageCount || 0;
+  }
+
+  /**
+   * Calculate recent trend
+   */
+  private calculateRecentTrend(team: Team): 'increasing' | 'decreasing' | 'stable' {
+    // This would use real usage data over time
+    return 'stable';
+  }
+
+  /**
+   * Get games played
+   */
+  private getGamesPlayed(team: Team, opponentTeam: Team): number {
+    // This would use real historical data
+    return Math.floor(Math.random() * 50) + 10;
+  }
+
+  /**
+   * Initialize meta data
+   */
+  private initializeMetaData(): void {
+    this.metaData = [
+      {
+        period: 'Current Season',
+        topPokemon: [
+          { name: 'Charizard', usage: 25, wins: 150, losses: 100, winRate: 0.6, tournaments: 10 },
+          { name: 'Blastoise', usage: 20, wins: 120, losses: 80, winRate: 0.6, tournaments: 10 },
+        ],
+        topItems: [
+          { name: 'Life Orb', usage: 30, wins: 180, losses: 120, winRate: 0.6 },
+          { name: 'Focus Sash', usage: 25, wins: 150, losses: 100, winRate: 0.6 },
+        ],
+        topMoves: [
+          { name: 'Protect', usage: 40, wins: 240, losses: 160, winRate: 0.6 },
+          { name: 'Flamethrower', usage: 20, wins: 120, losses: 80, winRate: 0.6 },
+        ],
+        formatChanges: ['New format introduced', 'Balance changes applied'],
+        emergingStrategies: ['Weather control teams', 'Speed control focus'],
+      },
+    ];
+  }
+
+  /**
+   * Generate unique ID
+   */
+  private generateId(): string {
+    return Math.random().toString(36).substr(2, 9);
+  }
+
+  /**
+   * Handle errors
+   */
+  private handleError(message: string, error: any): ApiResponse<any> {
+    const appError: AppError = {
+      code: 'TEAM_ANALYTICS_ERROR',
+      message,
+      details: error.message,
+      timestamp: new Date().toISOString(),
+    };
+
+    return {
+      success: false,
+      error: message,
+      timestamp: new Date().toISOString(),
+      requestId: this.generateId(),
+    };
+  }
+}
+
+export default TeamAnalyticsService.getInstance(); 

--- a/src/services/TournamentPolicyService.ts
+++ b/src/services/TournamentPolicyService.ts
@@ -1,0 +1,454 @@
+import { 
+  Tournament, 
+  ApiResponse, 
+  AppError 
+} from '../types';
+
+/**
+ * Service for managing tournament policies and restrictions
+ * Handles phone bans, device restrictions, and alternative tournament methods
+ */
+export class TournamentPolicyService {
+  private static instance: TournamentPolicyService;
+  private phoneBannedTournaments: Set<string> = new Set();
+  private tournamentPolicies: Map<string, TournamentPolicy> = new Map();
+
+  private constructor() {}
+
+  static getInstance(): TournamentPolicyService {
+    if (!TournamentPolicyService.instance) {
+      TournamentPolicyService.instance = new TournamentPolicyService();
+    }
+    return TournamentPolicyService.instance;
+  }
+
+  /**
+   * Set phone ban policy for a tournament
+   */
+  async setPhoneBanPolicy(
+    tournamentId: string, 
+    phoneBanned: boolean, 
+    policy: PhoneBanPolicy
+  ): Promise<ApiResponse<boolean>> {
+    try {
+      if (phoneBanned) {
+        this.phoneBannedTournaments.add(tournamentId);
+      } else {
+        this.phoneBannedTournaments.delete(tournamentId);
+      }
+
+      this.tournamentPolicies.set(tournamentId, {
+        phoneBanned,
+        policy,
+        updatedAt: new Date().toISOString(),
+      });
+
+      return {
+        success: true,
+        data: true,
+        timestamp: new Date().toISOString(),
+        requestId: this.generateId(),
+      };
+    } catch (error) {
+      return this.handleError('Failed to set phone ban policy', error);
+    }
+  }
+
+  /**
+   * Check if phones are banned for a tournament
+   */
+  isPhoneBanned(tournamentId: string): boolean {
+    return this.phoneBannedTournaments.has(tournamentId);
+  }
+
+  /**
+   * Get tournament policy
+   */
+  getTournamentPolicy(tournamentId: string): TournamentPolicy | null {
+    return this.tournamentPolicies.get(tournamentId) || null;
+  }
+
+  /**
+   * Get alternative methods for tournament operations when phones are banned
+   */
+  getAlternativeMethods(tournamentId: string, operation: TournamentOperation): AlternativeMethod[] {
+    const policy = this.getTournamentPolicy(tournamentId);
+    if (!policy || !policy.phoneBanned) {
+      return [];
+    }
+
+    const alternatives: { [key: string]: AlternativeMethod[] } = {
+      'match_reporting': [
+        {
+          method: 'paper_slip',
+          description: 'Use paper match slips with manual entry',
+          instructions: 'Fill out paper match slip and submit to judge for manual entry',
+          requiresJudge: true,
+        },
+        {
+          method: 'table_terminal',
+          description: 'Use dedicated tournament terminals at tables',
+          instructions: 'Use the provided tablet/terminal at your table for match reporting',
+          requiresJudge: false,
+        },
+        {
+          method: 'judge_assisted',
+          description: 'Have a judge assist with match reporting',
+          instructions: 'Call a judge to your table for match result entry',
+          requiresJudge: true,
+        },
+      ],
+      'pairing_check': [
+        {
+          method: 'pairing_board',
+          description: 'Check physical pairing board',
+          instructions: 'Look at the tournament pairing board for your match',
+          requiresJudge: false,
+        },
+        {
+          method: 'table_display',
+          description: 'Check table display',
+          instructions: 'Look at the display at your table for pairing information',
+          requiresJudge: false,
+        },
+        {
+          method: 'judge_announcement',
+          description: 'Listen for judge announcements',
+          instructions: 'Listen for judge announcements of pairings',
+          requiresJudge: true,
+        },
+      ],
+      'tournament_updates': [
+        {
+          method: 'announcement_board',
+          description: 'Check announcement board',
+          instructions: 'Check the tournament announcement board for updates',
+          requiresJudge: false,
+        },
+        {
+          method: 'judge_announcement',
+          description: 'Listen for judge announcements',
+          instructions: 'Listen for judge announcements of tournament updates',
+          requiresJudge: true,
+        },
+        {
+          method: 'table_display',
+          description: 'Check table display',
+          instructions: 'Check the display at your table for tournament updates',
+          requiresJudge: false,
+        },
+      ],
+      'team_verification': [
+        {
+          method: 'paper_team_sheet',
+          description: 'Use paper team sheet',
+          instructions: 'Submit paper team sheet for verification',
+          requiresJudge: true,
+        },
+        {
+          method: 'table_terminal',
+          description: 'Use dedicated tournament terminal',
+          instructions: 'Use the provided tablet/terminal for team verification',
+          requiresJudge: false,
+        },
+        {
+          method: 'judge_assisted',
+          description: 'Have judge assist with team verification',
+          instructions: 'Call a judge to verify your team',
+          requiresJudge: true,
+        },
+      ],
+      'dispute_resolution': [
+        {
+          method: 'judge_call',
+          description: 'Call a judge to your table',
+          instructions: 'Raise your hand or use the judge call button',
+          requiresJudge: true,
+        },
+        {
+          method: 'paper_dispute_form',
+          description: 'Fill out paper dispute form',
+          instructions: 'Fill out dispute form and submit to judge',
+          requiresJudge: true,
+        },
+      ],
+    };
+
+    return alternatives[operation] || [];
+  }
+
+  /**
+   * Get allowed devices for a tournament
+   */
+  getAllowedDevices(tournamentId: string): AllowedDevice[] {
+    const policy = this.getTournamentPolicy(tournamentId);
+    if (!policy || !policy.phoneBanned) {
+      return [
+        { type: 'phone', allowed: true, restrictions: [] },
+        { type: 'tablet', allowed: true, restrictions: [] },
+        { type: 'laptop', allowed: true, restrictions: [] },
+        { type: 'desktop', allowed: true, restrictions: [] },
+      ];
+    }
+
+    const phoneBanPolicy = policy.policy;
+    
+    return [
+      {
+        type: 'phone',
+        allowed: phoneBanPolicy.allowPhones,
+        restrictions: phoneBanPolicy.phoneRestrictions,
+      },
+      {
+        type: 'tablet',
+        allowed: phoneBanPolicy.allowTablets,
+        restrictions: phoneBanPolicy.tabletRestrictions,
+      },
+      {
+        type: 'laptop',
+        allowed: phoneBanPolicy.allowLaptops,
+        restrictions: phoneBanPolicy.laptopRestrictions,
+      },
+      {
+        type: 'desktop',
+        allowed: phoneBanPolicy.allowDesktops,
+        restrictions: phoneBanPolicy.desktopRestrictions,
+      },
+    ];
+  }
+
+  /**
+   * Check if a device is allowed for a tournament
+   */
+  isDeviceAllowed(tournamentId: string, deviceType: string, userAgent: string): boolean {
+    const allowedDevices = this.getAllowedDevices(tournamentId);
+    const device = allowedDevices.find(d => d.type === deviceType);
+    
+    if (!device || !device.allowed) {
+      return false;
+    }
+
+    // Check restrictions
+    for (const restriction of device.restrictions) {
+      if (restriction.type === 'user_agent' && userAgent.includes(restriction.value)) {
+        return false;
+      }
+      if (restriction.type === 'app' && userAgent.includes(restriction.value)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Get tournament check-in methods
+   */
+  getCheckInMethods(tournamentId: string): CheckInMethod[] {
+    const policy = this.getTournamentPolicy(tournamentId);
+    const isPhoneBanned = this.isPhoneBanned(tournamentId);
+
+    const methods: CheckInMethod[] = [
+      {
+        method: 'qr_code',
+        description: 'QR Code Check-in',
+        available: !isPhoneBanned,
+        instructions: 'Scan QR code with your phone',
+      },
+      {
+        method: 'manual_checkin',
+        description: 'Manual Check-in',
+        available: true,
+        instructions: 'Check in with tournament staff',
+      },
+      {
+        method: 'table_terminal',
+        description: 'Table Terminal Check-in',
+        available: isPhoneBanned,
+        instructions: 'Use the terminal at your table to check in',
+      },
+      {
+        method: 'judge_assisted',
+        description: 'Judge-Assisted Check-in',
+        available: true,
+        instructions: 'Have a judge check you in',
+      },
+    ];
+
+    return methods.filter(method => method.available);
+  }
+
+  /**
+   * Get tournament result submission methods
+   */
+  getResultSubmissionMethods(tournamentId: string): ResultSubmissionMethod[] {
+    const policy = this.getTournamentPolicy(tournamentId);
+    const isPhoneBanned = this.isPhoneBanned(tournamentId);
+
+    const methods: ResultSubmissionMethod[] = [
+      {
+        method: 'digital_match_slip',
+        description: 'Digital Match Slip',
+        available: !isPhoneBanned,
+        instructions: 'Submit results through the app',
+      },
+      {
+        method: 'paper_match_slip',
+        description: 'Paper Match Slip',
+        available: isPhoneBanned,
+        instructions: 'Fill out paper match slip and submit to judge',
+      },
+      {
+        method: 'table_terminal',
+        description: 'Table Terminal',
+        available: isPhoneBanned,
+        instructions: 'Use the terminal at your table to submit results',
+      },
+      {
+        method: 'judge_assisted',
+        description: 'Judge-Assisted Submission',
+        available: true,
+        instructions: 'Have a judge enter your results',
+      },
+    ];
+
+    return methods.filter(method => method.available);
+  }
+
+  /**
+   * Get communication methods during tournament
+   */
+  getCommunicationMethods(tournamentId: string): CommunicationMethod[] {
+    const policy = this.getTournamentPolicy(tournamentId);
+    const isPhoneBanned = this.isPhoneBanned(tournamentId);
+
+    const methods: CommunicationMethod[] = [
+      {
+        method: 'push_notifications',
+        description: 'Push Notifications',
+        available: !isPhoneBanned,
+        instructions: 'Receive notifications on your phone',
+      },
+      {
+        method: 'table_display',
+        description: 'Table Display',
+        available: isPhoneBanned,
+        instructions: 'Check the display at your table for updates',
+      },
+      {
+        method: 'announcement_board',
+        description: 'Announcement Board',
+        available: true,
+        instructions: 'Check the tournament announcement board',
+      },
+      {
+        method: 'judge_announcements',
+        description: 'Judge Announcements',
+        available: true,
+        instructions: 'Listen for judge announcements',
+      },
+      {
+        method: 'email_notifications',
+        description: 'Email Notifications',
+        available: true,
+        instructions: 'Check your email for tournament updates',
+      },
+    ];
+
+    return methods.filter(method => method.available);
+  }
+
+  /**
+   * Generate unique ID
+   */
+  private generateId(): string {
+    return Math.random().toString(36).substr(2, 9);
+  }
+
+  /**
+   * Handle errors
+   */
+  private handleError(message: string, error: any): ApiResponse<any> {
+    const appError: AppError = {
+      code: 'TOURNAMENT_POLICY_ERROR',
+      message,
+      details: error.message,
+      timestamp: new Date().toISOString(),
+    };
+
+    return {
+      success: false,
+      error: message,
+      timestamp: new Date().toISOString(),
+      requestId: this.generateId(),
+    };
+  }
+}
+
+// Types for tournament policies
+export interface TournamentPolicy {
+  phoneBanned: boolean;
+  policy: PhoneBanPolicy;
+  updatedAt: string;
+}
+
+export interface PhoneBanPolicy {
+  allowPhones: boolean;
+  allowTablets: boolean;
+  allowLaptops: boolean;
+  allowDesktops: boolean;
+  phoneRestrictions: DeviceRestriction[];
+  tabletRestrictions: DeviceRestriction[];
+  laptopRestrictions: DeviceRestriction[];
+  desktopRestrictions: DeviceRestriction[];
+  alternativeMethods: AlternativeMethod[];
+}
+
+export interface DeviceRestriction {
+  type: 'user_agent' | 'app' | 'feature';
+  value: string;
+  description: string;
+}
+
+export interface AlternativeMethod {
+  method: string;
+  description: string;
+  instructions: string;
+  requiresJudge: boolean;
+}
+
+export interface AllowedDevice {
+  type: string;
+  allowed: boolean;
+  restrictions: DeviceRestriction[];
+}
+
+export interface CheckInMethod {
+  method: string;
+  description: string;
+  available: boolean;
+  instructions: string;
+}
+
+export interface ResultSubmissionMethod {
+  method: string;
+  description: string;
+  available: boolean;
+  instructions: string;
+}
+
+export interface CommunicationMethod {
+  method: string;
+  description: string;
+  available: boolean;
+  instructions: string;
+}
+
+export type TournamentOperation = 
+  | 'match_reporting' 
+  | 'pairing_check' 
+  | 'tournament_updates' 
+  | 'team_verification' 
+  | 'dispute_resolution';
+
+export default TournamentPolicyService.getInstance(); 

--- a/src/tests/unit/CompetitorView.test.tsx
+++ b/src/tests/unit/CompetitorView.test.tsx
@@ -147,21 +147,21 @@ describe('CompetitorView', () => {
   };
 
   const mockOnLogout = jest.fn();
+  const mockOnGoHome = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   describe('Navigation Tests', () => {
-    test('should render with default tournaments tab', () => {
-      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} />);
+    test('should render with default home tab', () => {
+      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} onGoHome={mockOnGoHome} />);
       
-      expect(screen.getByText('Welcome, Trainer!')).toBeInTheDocument();
-      expect(screen.getByTestId('tournament-registration')).toBeInTheDocument();
+      expect(screen.getByText('Your Dashboard')).toBeInTheDocument();
     });
 
     test('should switch to pairings tab when clicked', () => {
-      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} />);
+      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} onGoHome={mockOnGoHome} />);
       
       const pairingsButton = screen.getByText('Pairings');
       fireEvent.click(pairingsButton);
@@ -170,7 +170,7 @@ describe('CompetitorView', () => {
     });
 
     test('should switch to calendar tab when clicked', () => {
-      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} />);
+      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} onGoHome={mockOnGoHome} />);
       
       const calendarButton = screen.getByText('Calendar');
       fireEvent.click(calendarButton);
@@ -179,7 +179,7 @@ describe('CompetitorView', () => {
     });
 
     test('should switch to search tab when clicked', () => {
-      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} />);
+      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} onGoHome={mockOnGoHome} />);
       
       const searchButton = screen.getByText('Search');
       fireEvent.click(searchButton);
@@ -188,18 +188,27 @@ describe('CompetitorView', () => {
     });
 
     test('should switch to blog tab when clicked', () => {
-      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} />);
+      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} onGoHome={mockOnGoHome} />);
       
       const blogButton = screen.getByText('Blog');
       fireEvent.click(blogButton);
       
       expect(screen.getByTestId('blog-tips')).toBeInTheDocument();
     });
+
+    test('should switch to following tab when clicked', () => {
+      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} onGoHome={mockOnGoHome} />);
+      
+      const followingButton = screen.getByText('Following');
+      fireEvent.click(followingButton);
+      
+      expect(screen.getByTestId('following-feed')).toBeInTheDocument();
+    });
   });
 
   describe('Player Selection Tests', () => {
     test('should show player profile when player is selected from following', async () => {
-      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} />);
+      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} onGoHome={mockOnGoHome} />);
       
       // Navigate to following tab
       const followingButton = screen.getByText('Following');
@@ -215,7 +224,7 @@ describe('CompetitorView', () => {
     });
 
     test('should show player profile when player is selected from search', async () => {
-      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} />);
+      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} onGoHome={mockOnGoHome} />);
       
       // Navigate to search tab
       const searchButton = screen.getByText('Search');
@@ -231,7 +240,7 @@ describe('CompetitorView', () => {
     });
 
     test('should allow navigation to other tabs when player profile is shown', async () => {
-      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} />);
+      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} onGoHome={mockOnGoHome} />);
       
       // Navigate to following and select player
       const followingButton = screen.getByText('Following');
@@ -248,12 +257,11 @@ describe('CompetitorView', () => {
       const tournamentsButton = screen.getByText('Events');
       fireEvent.click(tournamentsButton);
       
-      expect(screen.getByText('Welcome, Trainer!')).toBeInTheDocument();
-      expect(screen.getByTestId('tournament-registration')).toBeInTheDocument();
+      expect(screen.getByText('Tournament Events')).toBeInTheDocument();
     });
 
     test('should preserve profile tab state when navigating back to profile', async () => {
-      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} />);
+      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} onGoHome={mockOnGoHome} />);
       
       // Navigate to following and select player
       const followingButton = screen.getByText('Following');
@@ -282,7 +290,11 @@ describe('CompetitorView', () => {
 
   describe('Loading State Tests', () => {
     test('should disable buttons during loading', async () => {
-      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} />);
+      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} onGoHome={mockOnGoHome} />);
+      
+      // Navigate to tournaments tab to find registration button
+      const tournamentsButton = screen.getByText('Events');
+      fireEvent.click(tournamentsButton);
       
       // Trigger a loading state by clicking tournament registration
       const registerButton = screen.getByText('Register Now');
@@ -297,7 +309,11 @@ describe('CompetitorView', () => {
     });
 
     test('should show loading overlay during operations', async () => {
-      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} />);
+      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} onGoHome={mockOnGoHome} />);
+      
+      // Navigate to tournaments tab to find registration button
+      const tournamentsButton = screen.getByText('Events');
+      fireEvent.click(tournamentsButton);
       
       // Trigger loading state
       const registerButton = screen.getByText('Register Now');
@@ -339,20 +355,20 @@ describe('CompetitorView', () => {
   });
 
   describe('Quick Actions Tests', () => {
-    test('should navigate to calendar when View Calendar is clicked', () => {
-      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} />);
+    test('should navigate to calendar when Calendar is clicked', () => {
+      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} onGoHome={mockOnGoHome} />);
       
-      const viewCalendarButton = screen.getByText('View Calendar');
-      fireEvent.click(viewCalendarButton);
+      const calendarButton = screen.getByText('Calendar');
+      fireEvent.click(calendarButton);
       
       expect(screen.getByTestId('event-calendar')).toBeInTheDocument();
     });
 
-    test('should navigate to search when Search Players is clicked', () => {
-      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} />);
+    test('should navigate to search when Search is clicked', () => {
+      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} onGoHome={mockOnGoHome} />);
       
-      const searchPlayersButton = screen.getByText('Search Players');
-      fireEvent.click(searchPlayersButton);
+      const searchButton = screen.getByText('Search');
+      fireEvent.click(searchButton);
       
       expect(screen.getByTestId('player-search')).toBeInTheDocument();
     });
@@ -366,14 +382,14 @@ describe('CompetitorView', () => {
         mockPlayers: []
       }));
       
-      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} />);
+      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} onGoHome={mockOnGoHome} />);
       
       // Should still render without crashing
       expect(screen.getByText('VGC Hub')).toBeInTheDocument();
     });
 
     test('should handle missing player data gracefully', async () => {
-      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} />);
+      render(<CompetitorView userSession={mockUserSession} onLogout={mockOnLogout} onGoHome={mockOnGoHome} />);
       
       // Navigate to following tab
       const followingButton = screen.getByText('Following');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,11 +1,35 @@
+// Core Pokemon and Team Types
 export interface Pokemon {
   name: string;
   item?: string;
   ability?: string;
   teraType?: string;
   moves?: string[];
+  nature?: string;
+  evs?: { [stat: string]: number };
+  ivs?: { [stat: string]: number };
+  gender?: 'male' | 'female' | 'genderless';
+  shiny?: boolean;
+  level?: number;
 }
 
+export interface Team {
+  id: string;
+  name: string;
+  pokemon: Pokemon[];
+  format: string;
+  description?: string;
+  isPublic: boolean;
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+  tags: string[];
+  usageCount: number;
+  winRate?: number;
+  exportFormat?: 'showdown' | 'qr' | 'json';
+}
+
+// Enhanced Tournament Types
 export interface Tournament {
   id: string;
   name: string;
@@ -24,7 +48,8 @@ export interface Tournament {
   isRegistered?: boolean;
   requiresLottery?: boolean;
   registrationFee?: number;
-  // New scalable fields
+  
+  // Scalable registration fields
   maxCapacity: number;
   currentRegistrations: number;
   waitlistEnabled: boolean;
@@ -35,7 +60,8 @@ export interface Tournament {
   registrationQueue?: RegistrationQueue;
   lotterySettings?: LotterySettings;
   realTimeStats?: RealTimeStats;
-  // New fields for tournament creation and approval
+  
+  // Tournament creation and approval
   createdBy?: string;
   createdByProfessor?: {
     id: string;
@@ -60,8 +86,171 @@ export interface Tournament {
     contactInfo: string;
     specialRequirements?: string[];
   };
+
+  // Enhanced tournament features
+  tournamentType: 'swiss' | 'single-elimination' | 'double-elimination' | 'round-robin';
+  structure: TournamentStructure;
+  standings?: PlayerStanding[];
+  brackets?: Bracket[];
+  matchSlips?: MatchSlip[];
+  notifications?: TournamentNotification[];
+  qrCodes?: TournamentQRCode[];
 }
 
+export interface TournamentStructure {
+  totalRounds: number;
+  currentRound: number;
+  playersPerTable: number;
+  timePerRound: number;
+  breakTime: number;
+  cutToTop?: number;
+  swissRounds?: number;
+  eliminationRounds?: number;
+}
+
+export interface PlayerStanding {
+  playerId: string;
+  playerName: string;
+  record: string; // e.g., "5-2-0"
+  wins: number;
+  losses: number;
+  draws: number;
+  resistance: number;
+  opponentWinPercentage: number;
+  gameWinPercentage: number;
+  rank: number;
+  points: number;
+  isActive: boolean;
+  dropped: boolean;
+  lastMatchResult?: 'win' | 'loss' | 'draw';
+}
+
+export interface Bracket {
+  id: string;
+  name: string;
+  type: 'swiss' | 'single-elimination' | 'double-elimination';
+  round: number;
+  matches: BracketMatch[];
+  isActive: boolean;
+}
+
+export interface BracketMatch {
+  id: string;
+  player1Id: string;
+  player1Name: string;
+  player2Id: string;
+  player2Name: string;
+  winnerId?: string;
+  score?: string;
+  table: number;
+  status: 'pending' | 'in-progress' | 'completed' | 'disputed';
+  matchSlipId?: string;
+  startTime?: string;
+  endTime?: string;
+}
+
+// Digital Match Slip System
+export interface MatchSlip {
+  id: string;
+  tournamentId: string;
+  round: number;
+  table: number;
+  player1Id: string;
+  player1Name: string;
+  player2Id: string;
+  player2Name: string;
+  
+  // Game results
+  games: GameResult[];
+  winnerId?: string;
+  finalScore: string;
+  
+  // Digital signatures
+  player1Signature?: DigitalSignature;
+  player2Signature?: DigitalSignature;
+  
+  // Status and workflow
+  status: 'pending' | 'in-progress' | 'completed' | 'disputed' | 'resolved';
+  submittedAt?: string;
+  reviewedBy?: string;
+  reviewedAt?: string;
+  
+  // Dispute handling
+  dispute?: Dispute;
+  
+  // Audit trail
+  auditTrail: AuditEntry[];
+  
+  // QR code access (disabled during phone bans)
+  qrCode: string | null;
+  qrCodeExpiresAt: string | null;
+  
+  // Phone ban status
+  phoneBanned: boolean;
+}
+
+export interface GameResult {
+  gameNumber: number;
+  winnerId: string;
+  score: string; // e.g., "6-0", "2-0"
+  duration: number; // in minutes
+  notes?: string;
+  submittedBy: string;
+  submittedAt: string;
+}
+
+export interface DigitalSignature {
+  playerId: string;
+  signatureType: 'touch' | 'pin' | 'digital';
+  signatureData: string;
+  timestamp: string;
+  deviceInfo: DeviceInfo;
+  ipAddress?: string;
+}
+
+export interface DeviceInfo {
+  userAgent: string;
+  screenResolution: string;
+  timezone: string;
+  language: string;
+}
+
+export interface Dispute {
+  id: string;
+  raisedBy: string;
+  reason: string;
+  description: string;
+  evidence?: string[];
+  status: 'open' | 'under-review' | 'resolved';
+  assignedJudge?: string;
+  resolution?: string;
+  createdAt: string;
+  resolvedAt?: string;
+}
+
+export interface AuditEntry {
+  id: string;
+  action: string;
+  userId: string;
+  timestamp: string;
+  details: string;
+  ipAddress?: string;
+  deviceInfo?: DeviceInfo;
+}
+
+export interface TournamentQRCode {
+  id: string;
+  tournamentId: string;
+  type: 'match-slip' | 'check-in' | 'results';
+  code: string;
+  expiresAt: string;
+  isActive: boolean;
+  scannedAt?: string;
+  scannedBy?: string;
+  associatedData?: any;
+}
+
+// Enhanced Round and Match Types
 export interface Round {
   round: number;
   opponent: string;
@@ -70,8 +259,13 @@ export interface Round {
   result?: 'win' | 'loss' | 'draw';
   score?: string;
   table?: number;
+  matchSlipId?: string;
+  startTime?: string;
+  endTime?: string;
+  duration?: number;
 }
 
+// Enhanced Player Types
 export interface Player {
   id: string;
   name: string;
@@ -92,17 +286,156 @@ export interface Player {
     winRate: number;
     tournaments: number;
   }[];
-  // New fields for Pokémon Company approval
+  
+  // Pokémon Company approval
   isPokemonCompanyApproved?: boolean;
   approvalDate?: string;
   approvalLevel?: 'content_creator' | 'official_analyst' | 'brand_ambassador';
   specialBadges?: string[];
-  // New fields for professor status
+  
+  // Professor status
   isProfessor?: boolean;
   professorLevel?: 'assistant' | 'associate' | 'full' | 'emeritus';
   professorCertificationDate?: string;
   professorCertificationNumber?: string;
   canCreateTournaments?: boolean;
+  
+  // Live tournament status
+  isActiveInLiveTournament?: boolean;
+  currentTournament?: string;
+  currentRound?: number;
+  currentTable?: number;
+  currentMatch?: {
+    round: number;
+    table: number;
+    opponent: string;
+    opponentId: string;
+    result: 'win' | 'loss' | 'draw' | 'pending';
+  };
+
+  // Enhanced player features
+  teams: Team[];
+  matchHistory: MatchHistory[];
+  achievements: Achievement[];
+  statistics: PlayerStatistics;
+  preferences: PlayerPreferences;
+  accessibilitySettings: AccessibilitySettings;
+}
+
+export interface MatchHistory {
+  id: string;
+  tournamentId: string;
+  tournamentName: string;
+  opponentId: string;
+  opponentName: string;
+  result: 'win' | 'loss' | 'draw';
+  score: string;
+  date: string;
+  round: number;
+  table: number;
+  teamUsed: Pokemon[];
+  opponentTeam?: Pokemon[];
+  notes?: string;
+}
+
+export interface Achievement {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  unlockedAt: string;
+  category: 'tournament' | 'social' | 'team-building' | 'special';
+  rarity: 'common' | 'rare' | 'epic' | 'legendary';
+}
+
+export interface PlayerStatistics {
+  totalMatches: number;
+  totalWins: number;
+  totalLosses: number;
+  totalDraws: number;
+  winRate: number;
+  bestFinish: number;
+  tournamentsPlayed: number;
+  championships: number;
+  currentStreak: number;
+  longestStreak: number;
+  averagePlacement: number;
+  mostUsedPokemon: PokemonUsage[];
+  mostUsedItems: ItemUsage[];
+  mostUsedMoves: MoveUsage[];
+  seasonalStats: SeasonalStats[];
+}
+
+export interface PokemonUsage {
+  name: string;
+  usage: number;
+  wins: number;
+  losses: number;
+  winRate: number;
+  tournaments: number;
+}
+
+export interface ItemUsage {
+  name: string;
+  usage: number;
+  wins: number;
+  losses: number;
+  winRate: number;
+}
+
+export interface MoveUsage {
+  name: string;
+  usage: number;
+  wins: number;
+  losses: number;
+  winRate: number;
+}
+
+export interface SeasonalStats {
+  season: string;
+  matches: number;
+  wins: number;
+  losses: number;
+  winRate: number;
+  rating: number;
+  placement: number;
+}
+
+export interface PlayerPreferences {
+  notifications: NotificationPreferences;
+  privacy: PrivacySettings;
+  display: DisplayPreferences;
+  accessibility: AccessibilitySettings;
+  language: string;
+  timezone: string;
+}
+
+export interface NotificationPreferences {
+  email: boolean;
+  push: boolean;
+  sms: boolean;
+  tournamentUpdates: boolean;
+  pairingNotifications: boolean;
+  roundStartReminders: boolean;
+  socialInteractions: boolean;
+  achievementUnlocks: boolean;
+}
+
+export interface DisplayPreferences {
+  theme: 'light' | 'dark' | 'auto';
+  compactMode: boolean;
+  showAdvancedStats: boolean;
+  defaultView: 'dashboard' | 'tournaments' | 'teams' | 'social';
+}
+
+export interface AccessibilitySettings {
+  screenReader: boolean;
+  highContrast: boolean;
+  dyslexiaFriendly: boolean;
+  fontSize: 'small' | 'medium' | 'large' | 'extra-large';
+  reducedMotion: boolean;
+  keyboardNavigation: boolean;
+  colorBlindSupport: boolean;
 }
 
 export interface PrivacySettings {
@@ -110,10 +443,210 @@ export interface PrivacySettings {
   allowTeamReports: boolean;
   showTournamentHistory: boolean;
   allowQRCodeGeneration: boolean;
+  showOnlineStatus: boolean;
+  allowDirectMessages: boolean;
+  dataSharing: 'none' | 'anonymized' | 'full';
 }
 
+// Team Analytics and Meta Analysis
+export interface TeamAnalytics {
+  teamId: string;
+  usage: TeamUsage;
+  matchups: TeamMatchup[];
+  weaknesses: TeamWeakness[];
+  strengths: TeamStrength[];
+  recommendations: TeamRecommendation[];
+  metaTrends: MetaTrend[];
+}
 
+export interface TeamUsage {
+  totalUsage: number;
+  winRate: number;
+  averagePlacement: number;
+  tournaments: number;
+  recentTrend: 'increasing' | 'decreasing' | 'stable';
+}
 
+export interface TeamMatchup {
+  opponentTeam: Pokemon[];
+  winRate: number;
+  gamesPlayed: number;
+  difficulty: 'easy' | 'medium' | 'hard';
+  strategy: string;
+}
+
+export interface TeamWeakness {
+  type: string;
+  severity: 'low' | 'medium' | 'high';
+  description: string;
+  counterStrategies: string[];
+}
+
+export interface TeamStrength {
+  type: string;
+  description: string;
+  advantage: string;
+}
+
+export interface TeamRecommendation {
+  type: 'pokemon' | 'item' | 'move' | 'strategy';
+  suggestion: string;
+  reasoning: string;
+  impact: 'low' | 'medium' | 'high';
+}
+
+export interface MetaTrend {
+  period: string;
+  topPokemon: PokemonUsage[];
+  topItems: ItemUsage[];
+  topMoves: MoveUsage[];
+  formatChanges: string[];
+  emergingStrategies: string[];
+}
+
+// Community Features
+export interface Forum {
+  id: string;
+  name: string;
+  description: string;
+  category: 'general' | 'strategy' | 'tournament' | 'team-building' | 'meta-discussion';
+  threads: ForumThread[];
+  moderators: string[];
+  isActive: boolean;
+  createdAt: string;
+}
+
+export interface ForumThread {
+  id: string;
+  title: string;
+  content: string;
+  authorId: string;
+  authorName: string;
+  createdAt: string;
+  updatedAt: string;
+  replies: ForumReply[];
+  likes: number;
+  isLiked: boolean;
+  isPinned: boolean;
+  isLocked: boolean;
+  tags: string[];
+  viewCount: number;
+}
+
+export interface ForumReply {
+  id: string;
+  threadId: string;
+  content: string;
+  authorId: string;
+  authorName: string;
+  createdAt: string;
+  updatedAt: string;
+  likes: number;
+  isLiked: boolean;
+  isEdited: boolean;
+  parentReplyId?: string;
+}
+
+export interface DirectMessage {
+  id: string;
+  senderId: string;
+  receiverId: string;
+  content: string;
+  timestamp: string;
+  isRead: boolean;
+  messageType: 'text' | 'image' | 'file' | 'team-share';
+  attachments?: MessageAttachment[];
+}
+
+export interface MessageAttachment {
+  id: string;
+  type: 'image' | 'file' | 'team';
+  url: string;
+  name: string;
+  size: number;
+  teamData?: Team;
+}
+
+export interface GroupChat {
+  id: string;
+  name: string;
+  description: string;
+  members: GroupMember[];
+  messages: GroupMessage[];
+  isActive: boolean;
+  createdAt: string;
+  createdBy: string;
+}
+
+export interface GroupMember {
+  userId: string;
+  role: 'admin' | 'moderator' | 'member';
+  joinedAt: string;
+  isActive: boolean;
+}
+
+export interface GroupMessage {
+  id: string;
+  senderId: string;
+  content: string;
+  timestamp: string;
+  messageType: 'text' | 'image' | 'file' | 'team-share';
+  attachments?: MessageAttachment[];
+}
+
+// Notification System
+export interface Notification {
+  id: string;
+  userId: string;
+  type: 'tournament' | 'pairing' | 'social' | 'system' | 'achievement';
+  title: string;
+  message: string;
+  data?: any;
+  isRead: boolean;
+  createdAt: string;
+  expiresAt?: string;
+  actionUrl?: string;
+  priority: 'low' | 'medium' | 'high' | 'urgent';
+}
+
+export interface TournamentNotification extends Notification {
+  tournamentId: string;
+  round?: number;
+  table?: number;
+  actionRequired?: boolean;
+}
+
+// Calendar and Scheduling
+export interface CalendarEvent {
+  id: string;
+  title: string;
+  description: string;
+  startTime: string;
+  endTime: string;
+  type: 'tournament' | 'deadline' | 'reminder' | 'social';
+  tournamentId?: string;
+  isAllDay: boolean;
+  location?: string;
+  attendees?: string[];
+  reminders: CalendarReminder[];
+  recurrence?: CalendarRecurrence;
+}
+
+export interface CalendarReminder {
+  id: string;
+  type: 'push' | 'email' | 'sms';
+  timeBeforeEvent: number; // in minutes
+  isEnabled: boolean;
+}
+
+export interface CalendarRecurrence {
+  type: 'daily' | 'weekly' | 'monthly' | 'yearly';
+  interval: number;
+  endDate?: string;
+  daysOfWeek?: number[];
+}
+
+// Existing types (keeping for compatibility)
 export interface TeamReport {
   id: string;
   playerId: string;
@@ -186,11 +719,18 @@ export interface MetagameData {
 
 export interface UserSession {
   userId: string;
+  email: string;
   division: 'junior' | 'senior' | 'master';
+  isAdmin: boolean;
+  isProfessor: boolean;
+  isPokemonCompanyOfficial: boolean;
   isGuardian: boolean;
   guardianId?: string;
   permissions: string[];
-  dateOfBirth?: string; // Added for division determination
+  dateOfBirth?: string;
+  name?: string;
+  preferences?: PlayerPreferences;
+  accessibilitySettings?: AccessibilitySettings;
 }
 
 export interface BlogPost {
@@ -203,7 +743,6 @@ export interface BlogPost {
     avatar: string;
     isVerified: boolean;
     achievements: string[];
-    // New fields for Pokémon Company approved authors
     isPokemonCompanyApproved?: boolean;
     approvalLevel?: 'content_creator' | 'official_analyst' | 'brand_ambassador';
     specialBadges?: string[];
@@ -220,7 +759,6 @@ export interface BlogPost {
   isBookmarked: boolean;
   featuredImage?: string;
   summary: string;
-  // New fields for Pokémon Company content
   isOfficialContent?: boolean;
   requiresApproval?: boolean;
   approvalStatus?: 'pending' | 'approved' | 'rejected';
@@ -252,7 +790,6 @@ export interface AdminUser {
   createdAt: string;
 }
 
-// New scalable types for high-traffic registration
 export interface RegistrationQueue {
   id: string;
   tournamentId: string;
@@ -331,26 +868,17 @@ export interface TicketSale {
 export interface ScalableTournamentConfig {
   id: string;
   tournamentId: string;
-  // Load balancing
   maxConcurrentRegistrations: number;
   rateLimitPerUser: number;
   rateLimitPerIP: number;
-  
-  // Queue management
   queueEnabled: boolean;
   maxQueueSize: number;
   queueTimeoutMinutes: number;
-  
-  // Database optimization
   useReadReplicas: boolean;
   cacheEnabled: boolean;
   cacheTTL: number;
-  
-  // Monitoring
   enableRealTimeMonitoring: boolean;
   alertThresholds: AlertThresholds;
-  
-  // Fallback systems
   fallbackMode: 'graceful_degradation' | 'maintenance_mode' | 'emergency_shutdown';
   emergencyContact: string;
 }
@@ -419,4 +947,211 @@ export interface TournamentCreationRequest {
     role: string;
   };
   pokemonCompanyComments?: string;
+}
+
+// PWA and Mobile Features
+export interface PWAConfig {
+  name: string;
+  shortName: string;
+  description: string;
+  themeColor: string;
+  backgroundColor: string;
+  display: 'standalone' | 'fullscreen' | 'minimal-ui' | 'browser';
+  orientation: 'portrait' | 'landscape' | 'any';
+  scope: string;
+  startUrl: string;
+  icons: PWAIcon[];
+  screenshots?: PWAScreenshot[];
+  categories: string[];
+  lang: string;
+}
+
+export interface PWAIcon {
+  src: string;
+  sizes: string;
+  type: string;
+  purpose?: 'maskable' | 'any';
+}
+
+export interface PWAScreenshot {
+  src: string;
+  sizes: string;
+  type: string;
+  formFactor: 'wide' | 'narrow';
+  label: string;
+}
+
+// Feedback and Support
+export interface Feedback {
+  id: string;
+  userId: string;
+  type: 'bug' | 'feature-request' | 'general' | 'accessibility';
+  title: string;
+  description: string;
+  priority: 'low' | 'medium' | 'high' | 'critical';
+  status: 'open' | 'in-progress' | 'resolved' | 'closed';
+  category: string;
+  attachments?: string[];
+  createdAt: string;
+  updatedAt: string;
+  assignedTo?: string;
+  resolution?: string;
+  resolvedAt?: string;
+}
+
+// Data Export and Privacy
+export interface DataExport {
+  id: string;
+  userId: string;
+  type: 'tournament-history' | 'teams' | 'profile' | 'all-data';
+  status: 'pending' | 'processing' | 'completed' | 'failed';
+  format: 'json' | 'csv' | 'pdf';
+  downloadUrl?: string;
+  expiresAt: string;
+  createdAt: string;
+  completedAt?: string;
+  fileSize?: number;
+}
+
+// Pokémon Trainer Club Integration
+export interface PokemonTrainerClubAccount {
+  id: string;
+  userId: string;
+  ptcId: string;
+  ptcUsername: string;
+  isLinked: boolean;
+  linkedAt: string;
+  lastSync: string;
+  syncEnabled: boolean;
+  permissions: string[];
+}
+
+// API Response Types
+export interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  message?: string;
+  timestamp: string;
+  requestId: string;
+}
+
+export interface PaginatedResponse<T> extends ApiResponse<T[]> {
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+    hasNext: boolean;
+    hasPrev: boolean;
+  };
+}
+
+// WebSocket Event Types
+export interface WebSocketEvent {
+  type: string;
+  data: any;
+  timestamp: string;
+  userId?: string;
+}
+
+export interface PairingUpdateEvent extends WebSocketEvent {
+  type: 'pairing-update';
+  data: {
+    tournamentId: string;
+    round: number;
+    pairings: TournamentPairing[];
+  };
+}
+
+export interface MatchResultEvent extends WebSocketEvent {
+  type: 'match-result';
+  data: {
+    tournamentId: string;
+    matchSlipId: string;
+    result: MatchSlip;
+  };
+}
+
+export interface NotificationEvent extends WebSocketEvent {
+  type: 'notification';
+  data: Notification;
+}
+
+// Error Types
+export interface AppError {
+  code: string;
+  message: string;
+  details?: any;
+  timestamp: string;
+  userId?: string;
+  requestId?: string;
+}
+
+// Loading States
+export interface LoadingState {
+  isLoading: boolean;
+  error?: string;
+  progress?: number;
+  message?: string;
+}
+
+// Form Types
+export interface FormField {
+  name: string;
+  label: string;
+  type: 'text' | 'email' | 'password' | 'number' | 'select' | 'textarea' | 'checkbox' | 'radio' | 'date' | 'time';
+  required: boolean;
+  placeholder?: string;
+  options?: FormOption[];
+  validation?: ValidationRule[];
+  defaultValue?: any;
+}
+
+export interface FormOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+export interface ValidationRule {
+  type: 'required' | 'min' | 'max' | 'pattern' | 'email' | 'custom';
+  value?: any;
+  message: string;
+}
+
+// Theme and Styling
+export interface Theme {
+  name: string;
+  colors: {
+    primary: string;
+    secondary: string;
+    accent: string;
+    background: string;
+    surface: string;
+    text: string;
+    textSecondary: string;
+    border: string;
+    error: string;
+    warning: string;
+    success: string;
+    info: string;
+  };
+  fonts: {
+    primary: string;
+    secondary: string;
+  };
+  spacing: {
+    xs: string;
+    sm: string;
+    md: string;
+    lg: string;
+    xl: string;
+  };
+  borderRadius: {
+    sm: string;
+    md: string;
+    lg: string;
+    xl: string;
+  };
 }


### PR DESCRIPTION
- Add TournamentPolicyService to manage phone ban policies and device restrictions
- Update MatchSlipService to disable QR codes and touch signatures during phone bans
- Add paper match slip submission as alternative to digital methods
- Create TournamentPhoneBanHandler component for automatic alternative method detection
- Implement MatchResultSubmission component with phone ban considerations
- Update NotificationService to disable push notifications during phone bans
- Integrate phone ban handler into TournamentPairings component
- Add table-based match slip lookup as alternative to QR code scanning
- Support judge-assisted submission and manual verification workflows
- Include comprehensive audit trail for all submission methods
- Add device detection to prevent mobile access during phone bans
- Create detailed documentation for phone ban features and alternatives

Provides seamless tournament experience regardless of device restrictions by offering:
- Paper match slips with manual entry
- Table terminals for result submission
- Physical pairing boards and announcements
- Judge-assisted operations
- Email notifications between rounds

Fixes tournament compliance issues while maintaining digital benefits when phones are allowed.